### PR TITLE
[OXT-11] ndvm kernel command line: remove "swiotlb=force" option

### DIFF
--- a/templates/default/new-vm-ndvm
+++ b/templates/default/new-vm-ndvm
@@ -43,7 +43,7 @@
     "v4v": "true",
     "memory": "176",
     "display": "none",
-    "cmdline": "root=\/dev\/xvda1 swiotlb=force xencons=hvc0",
+    "cmdline": "root=\/dev\/xvda1 iommu=soft xencons=hvc0",
     "kernel-extract": "\/boot\/vmlinuz",
     "flask-label": "system_u:system_r:ndvm_t",
     "disk": {

--- a/templates/default/service-ndvm
+++ b/templates/default/service-ndvm
@@ -47,7 +47,7 @@
     "v4v": "true",
     "memory": "176",
     "display": "none",
-    "cmdline": "root=\/dev\/xvda1 swiotlb=force xencons=hvc0",
+    "cmdline": "root=\/dev\/xvda1 iommu=soft xencons=hvc0",
     "kernel-extract": "\/boot\/vmlinuz",
     "flask-label": "system_u:system_r:ndvm_t",
     "pci": {


### PR DESCRIPTION
This otion forces the usage of DMA "bounce buffers" which is
undesirable for performance and stability reasons.  It also
appears to break tg3 devices (packet data is garbage).  This
may be due to a bug somewhere else, but this option should
not be set regardless.

Replace "swiotlb=force" with "iommu=soft".

OXT-11

Signed-off-by: Chris Patterson pattersonc@ainfosec.com
