### PR TITLE
manager: add getter/setter for modify-usb-settings

### DIFF
--- a/xenmgr/XenMgr/Expose/XenmgrObject.hs
+++ b/xenmgr/XenMgr/Expose/XenmgrObject.hs
@@ -172,7 +172,9 @@ implementation xm testingCtx =
   , comCitrixXenclientXenmgrConfigUiSetModifyAdvancedVmSettings = \v -> dbWrite "/xenmgr/uiModifyAdvancedVmSettings" v >> cc
   , comCitrixXenclientXenmgrConfigUiGetModifyServices = fromMaybe True <$> dbMaybeRead "/xenmgr/uiModifyServices"
   , comCitrixXenclientXenmgrConfigUiSetModifyServices = \v -> dbWrite "/xenmgr/uiModifyServices" v >> cc
-  
+  , comCitrixXenclientXenmgrConfigUiGetModifyUsbSettings = fromMaybe True <$> dbMaybeRead "/xenmgr/uiModifyUsbSettings"
+  , comCitrixXenclientXenmgrConfigUiSetModifyUsbSettings = \v -> dbWrite "/xenmgr/uiModifyUsbSettings" v >> cc
+    
   , comCitrixXenclientPolicyEnforce    = \uuid -> policiesEnforce (fromString uuid)
   , comCitrixXenclientPolicyRetrieve   = \uuid -> policiesRetrieve (fromString uuid)
   , comCitrixXenclientXenmgrDiagSave   = \mode -> diagSave mode


### PR DESCRIPTION
Add a property to control this setting:
- namespace = com.citrix.xenclient.xenmgr.config.ui
- property name = modify-usb-settings
- property type = boolean
- default = true

OXT-115

Signed-off-by: Chris Patterson <pattersonc@ainfosec.com>