### PR TITLE
Rebase PV Linux driver on standard PVOPS kernel/xenbus.

### DIFF
--- a/templates/default/new-vm-linux
+++ b/templates/default/new-vm-linux
@@ -13,7 +13,6 @@
   "description": "Linux (Debian, Ubuntu)",
   "os": "linux",
   "ui-selectable": "true",
-  "xci-cpuid-signature": "true",
   "stubdom": "true",
   "config": {
     "notify": "dbus",


### PR DESCRIPTION
Get rid of the CPUID that allowed the xc-xen platform
device to load.

OXT-231

Signed-off-by: Ross Philipson <philipsonr@ainfosec.com>