### PR TITLE
upgrade-db: add migrations 24->25 and 25->26 to match current configs

### DIFF
--- a/upgrade-db/Migrations.hs
+++ b/upgrade-db/Migrations.hs
@@ -44,6 +44,8 @@ import qualified Migrations.M_20
 import qualified Migrations.M_21
 import qualified Migrations.M_22
 import qualified Migrations.M_23
+import qualified Migrations.M_24
+import qualified Migrations.M_25
 
 migrations :: [Migration]
 migrations = [ Migrations.M_1.migration
@@ -69,6 +71,8 @@ migrations = [ Migrations.M_1.migration
              , Migrations.M_21.migration
              , Migrations.M_22.migration
              , Migrations.M_23.migration
+             , Migrations.M_24.migration
+             , Migrations.M_25.migration
              ]
 
 getMigrationFromVer :: Int -> Migration

--- a/upgrade-db/Migrations/M_24.hs
+++ b/upgrade-db/Migrations/M_24.hs
@@ -1,0 +1,48 @@
+--
+-- Copyright (c) 2015 Assured Information Security, Inc. <pattersonc@ainfosec.com>
+-- Copyright (c) 2014 Citrix Systems, Inc.
+-- 
+-- This program is free software; you can redistribute it and/or modify
+-- it under the terms of the GNU General Public License as published by
+-- the Free Software Foundation; either version 2 of the License, or
+-- (at your option) any later version.
+-- 
+-- This program is distributed in the hope that it will be useful,
+-- but WITHOUT ANY WARRANTY; without even the implied warranty of
+-- MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+-- GNU General Public License for more details.
+-- 
+-- You should have received a copy of the GNU General Public License
+-- along with this program; if not, write to the Free Software
+-- Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+--
+
+{-# LANGUAGE PatternGuards, ViewPatterns #-}
+
+-- description: ac97 is now supported in windows guests with latest openxt tools
+-- date: 04/30/2015
+
+module Migrations.M_24 (migration) where
+
+import UpgradeEngine
+import Data.List (foldl')
+import ShellTools
+import Control.Monad
+import Directory
+
+migration = Migration {
+              sourceVersion = 24
+            , targetVersion = 25
+            , actions = act
+            }
+
+act :: IO ()
+act = updateAudioBackend
+
+updateAudioBackend = xformVmJSON xform where
+  xform tree = case jsGet "/os" tree of
+    Just (jsUnboxString -> s)
+      | (    s == "windows"
+          || s == "windows8" ) -> jsSet "/config/sound" (jsBoxString "ac97") tree
+    _ -> tree
+

--- a/upgrade-db/Migrations/M_25.hs
+++ b/upgrade-db/Migrations/M_25.hs
@@ -1,0 +1,45 @@
+--
+-- Copyright (c) 2015 Assured Information Security, Inc. <pattersonc@ainfosec.com>
+-- Copyright (c) 2014 Citrix Systems, Inc.
+-- 
+-- This program is free software; you can redistribute it and/or modify
+-- it under the terms of the GNU General Public License as published by
+-- the Free Software Foundation; either version 2 of the License, or
+-- (at your option) any later version.
+-- 
+-- This program is distributed in the hope that it will be useful,
+-- but WITHOUT ANY WARRANTY; without even the implied warranty of
+-- MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+-- GNU General Public License for more details.
+-- 
+-- You should have received a copy of the GNU General Public License
+-- along with this program; if not, write to the Free Software
+-- Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+--
+
+{-# LANGUAGE PatternGuards #-}
+
+-- description: match current ndvm kernel command line args
+--              replacing swiotlb=force with iommu=soft
+-- date: 04/30/2015
+
+module Migrations.M_25 (migration) where
+
+import UpgradeEngine
+import Data.List (foldl')
+
+migration = Migration {
+              sourceVersion = 25
+            , targetVersion = 26
+            , actions = act
+            }
+
+act :: IO ()
+act = updateNdvm
+
+updateNdvm = xformVmJSON xform where
+  xform tree = case jsGet "/type" tree of
+    Just s | jsUnboxString s == "ndvm" -> modify tree
+    _ -> tree
+    where
+      modify = jsSet "/config/cmdline" (jsBoxString "root=/dev/xvda1 iommu=soft xencons=hvc0")

--- a/upgrade-db/Upgrade.hs
+++ b/upgrade-db/Upgrade.hs
@@ -40,7 +40,7 @@ import qualified Data.Text as T
 
 -- MODIFY THIS WHEN FORMAT CHANGES
 latestVersion :: Int
-latestVersion = 24
+latestVersion = 26
 ----------------------------------
 
 dbdRunning :: IO Bool


### PR DESCRIPTION
24->25: AC97 is now the desired setting for windows guests with latest
openxt tools.

25->26: Update ndvm kernel command line parameters to match the current
ndvm template configuration: "root=/dev/xvda1 iommu=soft xencons=hvc0"

OXT-273
OXT-274

Signed-off-by: Chris Patterson <pattersonc@ainfosec.com>