### PR TITLE
Implement proper monadic evaluation and filtering with mapM_

### DIFF
--- a/xenmgr/Vm/Actions.hs
+++ b/xenmgr/Vm/Actions.hs
@@ -508,12 +508,12 @@ startVmInternal uuid = do
         then do
           gfxbdf <- getVmGpu uuid
           devices <- liftIO pciGetDevices
-          let devMatches = filter (bdFilter (take 7 gfxbdf)) devices in
-              foldl1 seq (map (add_pt_rule_bdf uuid) devMatches)
+          let devMatches = filter (bdFilter (take 7 gfxbdf) gfxbdf) devices in
+              mapM_ (add_pt_rule_bdf uuid) devMatches
         else return ()
 
-    --Filter function to match on domain:bus:device
-    bdFilter match d = isInfixOf match (show (devAddr d))
+    --Filter function to match on domain:bus and also filter out the video function
+    bdFilter match bdf d = (isInfixOf match (show (devAddr d))) && (bdf /= (show (devAddr d))) 
 
     --Check if vm has a bdf in gpu
     isGpuPt uuid = do


### PR DESCRIPTION
Vm/Actions.hs

  * Use mapM_ to force evaluation of all Rpc monadic computations
    to make sure we add every function/device that matches.
  * Additionally ensure we filter out the video function of gpu to
    avoid passing it through twice.

OXT-296

Signed-off-by: Chris Rogers <rogersc@ainfosec.com>