### PR TITLE
xenmgr: add switcher-status-report-enabled property to configure

### DIFF
--- a/xenmgr/XenMgr/Config.hs
+++ b/xenmgr/XenMgr/Config.hs
@@ -57,6 +57,7 @@ module XenMgr.Config
                  , appGetSwitcherSelfSwitchEnabled, appSetSwitcherSelfSwitchEnabled
                  , appGetSwitcherKeyboardFollowsMouse, appSetSwitcherKeyboardFollowsMouse
                  , appGetSwitcherResistance, appSetSwitcherResistance
+                 , appGetSwitcherStatusReportEnabled, appSetSwitcherStatusReportEnabled
                  , appGetDrmGraphics, appSetDrmGraphics
                  , appGetSupportedLanguages
                  , appGetLanguage, appSetLanguage
@@ -290,6 +291,10 @@ appGetSwitcherResistance = dbReadWithDefault 10 "/switcher/resistance"
 
 appSetSwitcherResistance :: Int -> Rpc ()
 appSetSwitcherResistance v = dbWrite "/switcher/resistance" v
+
+appGetSwitcherStatusReportEnabled :: Rpc Bool
+appGetSwitcherStatusReportEnabled = dbReadWithDefault True "/switcher/status-report-enabled"
+appSetSwitcherStatusReportEnabled v = dbWrite "/switcher/status-report-enabled" v
 
 appGetSupportedLanguages :: Rpc [String]
 appGetSupportedLanguages = parse <$> liftM (M.lookup "supported-languages") (liftIO readCaps) where

--- a/xenmgr/XenMgr/Expose/XenmgrObject.hs
+++ b/xenmgr/XenMgr/Expose/XenmgrObject.hs
@@ -145,6 +145,8 @@ implementation xm testingCtx =
   , comCitrixXenclientXenmgrConfigUiSetSwitcherKeyboardFollowsMouse = appSetSwitcherKeyboardFollowsMouse
   , comCitrixXenclientXenmgrConfigUiGetSwitcherResistance = fromIntegral <$> appGetSwitcherResistance
   , comCitrixXenclientXenmgrConfigUiSetSwitcherResistance = appSetSwitcherResistance . fromIntegral
+  , comCitrixXenclientXenmgrConfigUiGetSwitcherStatusReportEnabled = appGetSwitcherStatusReportEnabled
+  , comCitrixXenclientXenmgrConfigUiSetSwitcherStatusReportEnabled = appSetSwitcherStatusReportEnabled
 
   , comCitrixXenclientXenmgrConfigUiGetSupportedLanguages = appGetSupportedLanguages
   , comCitrixXenclientXenmgrConfigUiGetLanguage = appGetLanguage


### PR DESCRIPTION
the input server to respond to CTRL+ALT+R when UI is focused.

OXT-335

Signed-off-by: Chris Patterson <pattersonc@ainfosec.com>