### PR TITLE
[v4v] Remove domU access ports to dom0

### DIFF
--- a/templates/default/new-vm
+++ b/templates/default/new-vm
@@ -1,12 +1,10 @@
 {
   "type": "svm",
   "v4v-firewall-rules": {
-    "0": "myself -> 0:80",
-    "1": "myself -> 0:5556",
-    "2": "my-stubdom -> 0:4001",
-    "3": "my-stubdom -> 0:4002",
-    "4": "my-stubdom -> 0:5000",
-    "5": "my-stubdom -> 0:5001"
+    "0": "my-stubdom -> 0:4001",
+    "1": "my-stubdom -> 0:4002",
+    "2": "my-stubdom -> 0:5000",
+    "3": "my-stubdom -> 0:5001"
   },
   "os": "windows",
   "description": "Windows 7",

--- a/templates/default/new-vm-linux
+++ b/templates/default/new-vm-linux
@@ -1,12 +1,10 @@
 {
   "type": "svm",
   "v4v-firewall-rules": {
-    "0": "myself -> 0:80",
-    "1": "myself -> 0:5556",
-    "2": "my-stubdom -> 0:4001",
-    "3": "my-stubdom -> 0:4002",
-    "4": "my-stubdom -> 0:5000",
-    "5": "my-stubdom -> 0:5001"
+    "0": "my-stubdom -> 0:4001",
+    "1": "my-stubdom -> 0:4002",
+    "2": "my-stubdom -> 0:5000",
+    "3": "my-stubdom -> 0:5001"
   },
   "description": "Linux (Debian, Ubuntu)",
   "os": "linux",

--- a/templates/default/new-vm-windows8
+++ b/templates/default/new-vm-windows8
@@ -1,12 +1,10 @@
 {
   "type": "svm",
   "v4v-firewall-rules": {
-    "0": "myself -> 0:80",
-    "1": "myself -> 0:5556",
-    "2": "my-stubdom -> 0:4001",
-    "3": "my-stubdom -> 0:4002",
-    "4": "my-stubdom -> 0:5000",
-    "5": "my-stubdom -> 0:5001"
+    "0": "my-stubdom -> 0:4001",
+    "1": "my-stubdom -> 0:4002",
+    "2": "my-stubdom -> 0:5000",
+    "3": "my-stubdom -> 0:5001"
   },
   "os": "windows8",
   "description": "Windows 8/10",

--- a/templates/default/new-vm-xp
+++ b/templates/default/new-vm-xp
@@ -1,12 +1,10 @@
 {
   "type": "svm",
   "v4v-firewall-rules": {
-    "0": "myself -> 0:80",
-    "1": "myself -> 0:5556",
-    "2": "my-stubdom -> 0:4001",
-    "3": "my-stubdom -> 0:4002",
-    "4": "my-stubdom -> 0:5000",
-    "5": "my-stubdom -> 0:5001"
+    "0": "my-stubdom -> 0:4001",
+    "1": "my-stubdom -> 0:4002",
+    "2": "my-stubdom -> 0:5000",
+    "3": "my-stubdom -> 0:5001"
   },
   "os": "windows",
   "description": "Windows XP",


### PR DESCRIPTION
Now that the win-tools are gone that used these ports, they can be closed
down.

OXT-563

Signed-off-by: Ross Philipson <philipsonr@ainfosec.com>