### PR TITLE
Replace hvm-info with xenops physinfo instead.

### DIFF
--- a/xenmgr/XenMgr/Host.hs
+++ b/xenmgr/XenMgr/Host.hs
@@ -400,9 +400,9 @@ isAMTCapable =
 
 getHvmInfo :: IO HvmInfo
 getHvmInfo = do
-    text <- T.pack <$> spawnShell "hvm-info"
-    let hvm = T.count "hvm is enabled" text > 0
-        directio = T.count "hvm_directio is enabled" text > 0
+    text <- T.pack <$> spawnShell "xenops physinfo"
+    let hvm = T.count "hvm" text > 0
+        directio = T.count "directio" text > 0
     return $ HvmInfo { hvmEnabled = hvm
                      , hvmDirectIOEnabled = directio }
 


### PR DESCRIPTION
xenops (CAML toosltack) provides access to xc_physinfo without the need
for a standalone binary, so use that instead of hvm-info.

OXT-586