### PR TITLE
[ota] STABLE-6 Don't download tarballs twice.

### DIFF
--- a/updatemgr/UpdateMgr/Logic.hs
+++ b/updatemgr/UpdateMgr/Logic.hs
@@ -318,7 +318,7 @@ downloadAndCheckUpdateMetaAny how infoUrl = do
   case applicable of
     UpToDate -> return ()
     CannotUpgrade -> throwError $ localE UpdateNotApplicable
-    CanUpgrade -> downloadFiles
+    CanUpgrade -> return ()
 
 downloadFiles :: Update ()
 downloadFiles = do


### PR DESCRIPTION
Use the forground step to download the meta files and the background
step to do the main download. This also fixes some oddities with the UI.

OXT-734

Signed-off-by: Ross Philipson <philipsonr@ainfosec.com>