### PR TITLE
xenmgr: handle empty power management actions as "nothing"

### DIFF
--- a/xenmgr/XenMgr/PowerManagement.hs
+++ b/xenmgr/XenMgr/PowerManagement.hs
@@ -111,7 +111,8 @@ pmActionOfStr "shutdown"  = ActionShutdown
 pmActionOfStr "forced-shutdown" = ActionForcedShutdown
 pmActionOfStr "reboot"    = ActionReboot
 pmActionOfStr "nothing"   = ActionNothing
-pmActionOfStr _           = error "incorrect pm action specification"
+pmActionOfStr ""          = ActionNothing
+pmActionOfStr bad         = error ("incorrect pm action specification: " ++ bad)
 
 pmActionToStr ActionSleep     = "sleep"
 pmActionToStr ActionHibernate = "hibernate"


### PR DESCRIPTION
and log wrong values

OXT-866

Signed-off-by: Jed <lejosnej@ainfosec.com>