### PR TITLE
[libxl] Fix bug with cdrom access

### DIFF
--- a/xenmgr/Vm/Config.hs
+++ b/xenmgr/Vm/Config.hs
@@ -705,7 +705,7 @@ miscSpecs cfg = do
     let cdexcl_opt = case vmcfgCdExclusive cfg of
                        True -> "-exclusive"
                        _    -> ""
-    let cdromParams = let bsgList = map cdromParam bsgs in
+    let cdromParams = let bsgList = if cdromA then map cdromParam bsgs else [] in
                         case length bsgList of
                            0 -> []
                            _ -> (["-drive"] ++) $ intersperse "-drive" bsgList


### PR DESCRIPTION
  If a domain disables cdrom access, the "-drive" entry is still
  placed in the device_model_params, which, by itself, fails to
  parse in qemu causing the domain to fail to boot.

  OXT-435

Signed-off-by: Chris Rogers <rogersc@ainfosec.com>