### PR TITLE
[xenmgr] Fix naming scheme for temp vhds

### DIFF
--- a/xenmgr/Vm/Actions.hs
+++ b/xenmgr/Vm/Actions.hs
@@ -769,7 +769,9 @@ monitorAcpi uuid m state = do
 createSnapshot :: Disk -> IO Disk
 createSnapshot disk = do
     let path = diskPath disk
-    let newPath = path ++ ".snap.tmp.vhd"
+    let splitPath = split '/' path
+    let newname = "snap_" ++ (last splitPath) ++ ".snap.tmp.vhd"
+    let newPath = intercalate "/" $ (reverse $ drop 1 $ reverse splitPath) ++ [newname] 
     exists <- liftIO $ doesFileExist newPath --ensure we're creating a fresh snapshot
     when exists (removeFile newPath)
     create path newPath


### PR DESCRIPTION
  When disk persistence is set to false, we use non-encrypted
  snapshots.  If the parent disk is encrypted and the snapshot
  shares the same name, we can fall into an error case in blktap2
  crypto code meant to catch when an encrypted disk is replaced
  with a blank disk. This commit prepends to the snapshot name so
  it's unlikely we hit this case.

  OXT-966

Signed-off-by: Chris Rogers <rogersc@ainfosec.com>