### PR TITLE
If there's no state node, don't fire a shutdown

### DIFF
--- a/xenmgr/Vm/React.hs
+++ b/xenmgr/Vm/React.hs
@@ -529,7 +529,7 @@ notifyVmStateUpdate = do
     st s =
       case s of
         Just state -> (fromString "vm:state:" ++ state)
-        Nothing -> (fromString "vm:state:shutdown")
+        Nothing -> (fromString "")
 
 notifyVmStateChange :: VmState -> Vm ()
 notifyVmStateChange state


### PR DESCRIPTION
event.

OXT-973

Signed-off-by: Chris Rogers <rogersc@ainfosec.com>