### PR TITLE
STABLE-6: Add ActionInvalid PMAction type designed to log

### DIFF
--- a/xenmgr/XenMgr/PowerManagement.hs-boot
+++ b/xenmgr/XenMgr/PowerManagement.hs-boot
@@ -10,6 +10,7 @@ data PMAction = ActionSleep
 	      | ActionForcedShutdown
               | ActionReboot
               | ActionNothing
+              | ActionInvalid
 
 instance Show PMAction
 instance Eq PMAction


### PR DESCRIPTION
the use of a bad action and then do nothing.

OXT-866

Signed-off-by: Chris Rogers <rogersc@ainfosec.com>
(cherry picked from commit e573818be505bc37cef49c67b9f9782e406f930c)
Signed-off-by: Jed <lejosnej@ainfosec.com>