### PR TITLE
[xenmgr] Reconnect vifs on ndvm reboot

### DIFF
--- a/xenmgr/Vm/Dm.hs
+++ b/xenmgr/Vm/Dm.hs
@@ -24,6 +24,7 @@ module Vm.Dm
 
 import Control.Monad
 import Control.Applicative
+import Control.Concurrent
 import Data.String
 import Data.Maybe
 import Text.Printf
@@ -34,6 +35,8 @@ import Vm.Uuid
 
 import qualified XenMgr.Connect.Xl as Xl
 import XenMgr.Rpc
+import XenMgr.Db
+import XenMgr.Connect.NetworkDaemon as ND
 
 import Tools.XenStore
 import Tools.Misc
@@ -145,4 +148,23 @@ moveBackend t frontdomid id backdomid = do
       moveNIC dev =
           do info $ printf "moving NIC (%s) backend to domid=%d" (show dev) backdomid
              uuid <- fromMaybe (error "failed to get domain UUID") <$> getDomainUuid frontdomid
-             liftIO $ Xl.setNicBackendDom uuid id backdomid
+             backuuid <- fromMaybe (error "failed to get domain UUID") <$> getDomainUuid backdomid
+             nicNet <- dbReadWithDefault "" ("/vm/" ++ (show uuid) ++"/config/nic/" ++ (show id) ++ "/network")
+             case (nicNet /= "") of
+                 True   -> do liftIO $ Xl.removeNic uuid id backdomid
+                              vifConnect uuid id nicNet frontdomid backdomid 30
+                 False  -> return ()
+      -- Try to hook up the vif to the backend, retrying for specified timeout in seconds
+      -- Rpc calls are also wrapped in their own retry block in case dbus isn't ready in the ndvm
+      vifConnect uuid id nicNet frontdomid backdomid timeout =
+          do liftIO $ Xl.addNic uuid id nicNet backdomid
+             connected <- rpcRetry (ND.vifConnected frontdomid id backdomid)
+             case (connected, timeout > 0) of
+                (True, _)        -> return ()
+                (False, False)   -> return ()
+                (False, True)    -> do liftIO $ threadDelay(10^6)
+                                       vifConnect uuid id nicNet frontdomid backdomid (timeout-1)
+      rpcRetry f = rpcRetryOnError 10 1000 retryCheck f
+      retryCheck e = case toRemoteErr e of
+                     Nothing  -> False
+                     Just err -> True

--- a/xenmgr/Vm/DmTypes.hs
+++ b/xenmgr/Vm/DmTypes.hs
@@ -170,7 +170,7 @@ networkStateFromStr s = read s :: Int
 -- TODO: ideally this could be handled somewhere in the upgrade process
 legacyNNames "brbridged" = "/wired/0/bridged"
 legacyNNames "brshared" = "/wired/0/shared"
-legacyNNames "brwireless" = "/wireless/0/shared"
+legacyNNames "brwireless" = "/wifi/0/shared"
 legacyNNames "brinternal" = "/internal"
 legacyNNames x = x
 

--- a/xenmgr/Vm/State.hs
+++ b/xenmgr/Vm/State.hs
@@ -83,11 +83,11 @@ updateVmInternalState uuid s = liftIO (xsWrite (internalStatePath uuid) (stateTo
 getVmInternalState :: MonadRpc e m => Uuid -> m VmState
 getVmInternalState uuid = fromMaybe Shutdown . fmap stateFromStr <$> (liftIO $ xsRead (internalStatePath uuid))
 
-waitForVmInternalState :: MonadRpc e m => Uuid -> VmState -> Int -> m ()
-waitForVmInternalState uuid state to_secs = do
+waitForVmInternalState :: MonadRpc e m => Uuid -> VmState -> VmState -> Int -> m ()
+waitForVmInternalState uuid state cond_state to_secs = do
   i_state <- getVmInternalState uuid
   info $ "waitForState: i_state: " ++ (stateToStr i_state) ++ " state: " ++ (stateToStr state)
-  if (stateToStr i_state) == (stateToStr state) then do return ()
+  if (stateToStr i_state) == (stateToStr state)  || ((stateToStr i_state) == (stateToStr cond_state)) then do return ()
     else do
            info $ printf "Wait for vm %s state to become %s" (show uuid) stateStr
            handle =<< ( liftIO $ timeout (10^6 * to_secs) (xsWaitFor (internalStatePath uuid) check) )

--- a/xenmgr/XenMgr/Connect/NetworkDaemon.hs
+++ b/xenmgr/XenMgr/Connect/NetworkDaemon.hs
@@ -24,6 +24,7 @@ module XenMgr.Connect.NetworkDaemon
     , anyNetworksActive
     , onNetworkAdded, onNetworkRemoved, onNetworkStateChanged, onNetworkStateChangedRemove
     , getNetworkBackend'
+    , vifConnected
     , netbackToUuid
     ) where
 
@@ -62,6 +63,9 @@ npathS = TL.unpack . strObjectPath . networkObjectPath
 
 ready :: Rpc Bool
 ready = comCitrixXenclientNetworkdaemonIsInitialized service rootS
+
+vifConnected :: DomainID -> NicID -> DomainID -> Rpc Bool
+vifConnected frontdomid nicid backdomid = comCitrixXenclientNetworkdaemonVifConnected service rootS (vifS frontdomid nicid) backdomid
 
 repeatUntil :: (MonadIO m) => m Bool -> Float -> Float -> m Bool
 repeatUntil pred delay to

--- a/xenmgr/XenMgr/PowerManagement.hs
+++ b/xenmgr/XenMgr/PowerManagement.hs
@@ -258,7 +258,7 @@ pmShutdownVms force = do
               when (t == HDX) (switchVm uuid >> return())
               -- ensure the VM is considered dead internally (i.e. shutdown even handlers have ran)
               -- by waiting for internal Shutdown state upto 3 secs
-              (shutdownVm uuid >> waitForVmInternalState uuid Shutdown 3)
+              (shutdownVm uuid >> waitForVmInternalState uuid Shutdown Shutdown 3)
                 `catchError` shutdownError
 
     --FIXME! : should really translate xenvm errors into something better than strings


### PR DESCRIPTION
  Fix a few bugs along this control path in addition to new logic
  for applyVmBackendShift. When ndvm_x reboots, forall frontends
  with ndvm_x as a backend, cleanup all existing frontend nics and
  call into networkdaemon to hookup new vifs for ndvm_x.

  OXT-1011

Signed-off-by: Chris Rogers <rogersc@ainfosec.com>