### PR TITLE
[Xen 4.9] Increase stubdom memory from 80M to 96M

### DIFF
--- a/xenmgr/Vm/Queries.hs
+++ b/xenmgr/Vm/Queries.hs
@@ -447,7 +447,7 @@ getVmStubdom :: Uuid -> Rpc Bool
 getVmStubdom uuid = readConfigPropertyDef uuid vmStubdom False
 
 getVmStubdomMemory :: Uuid -> Rpc Int
-getVmStubdomMemory uuid = readConfigPropertyDef uuid vmStubdomMemory 80
+getVmStubdomMemory uuid = readConfigPropertyDef uuid vmStubdomMemory 96
 
 getVmStubdomCmdline :: Uuid -> Rpc String
 getVmStubdomCmdline uuid = readConfigPropertyDef uuid vmStubdomCmdline ""


### PR DESCRIPTION
80M has been observed as too low to allow a guest VM to reboot.

OXT-1203 for Xen upgrade.

Signed-off-by: Christopher Clark <christopher.clark6@baesystems.com>