### PR TITLE
STABLE-7: [xenmgr] Don't use temporary-encrypted

### DIFF
--- a/xenmgr/XenMgr/Expose/VmDiskObject.hs
+++ b/xenmgr/XenMgr/Expose/VmDiskObject.hs
@@ -188,13 +188,7 @@ _GetSnapshot id =
 
 _SetSnapshot :: ID -> String -> Vm ()
 _SetSnapshot id "none" = _modify_disk id $ \d -> d { diskSnapshotMode = Nothing }
-_SetSnapshot id s      = do
-                            enc <- liftRpc $ _GetEncryptionKeySet id
-                            if enc
-                              then
-                                _modify_disk id $ \d -> d { diskSnapshotMode = Just $ enumMarshallReverse_ "temporary-encrypted" }
-                              else
-                                _modify_disk id $ \d -> d { diskSnapshotMode = Just $ enumMarshallReverse_ s }
+_SetSnapshot id s      = _modify_disk id $ \d -> d { diskSnapshotMode = Just $ enumMarshallReverse_ s }
 
 
 _GetEncryptionKeySet :: ID -> Rpc Bool


### PR DESCRIPTION
  The option isn't implemented well enough, just key off whether
  the encryption key is set or not to make an encrypted snapshot.

  OXT-966

Signed-off-by: Chris <rogersc@ainfosec.com>