### PR TITLE
STABLE-7: xenmgr: use readProcessOrDie to avoid fd leaks

### DIFF
--- a/xenmgr/Vm/Actions.hs
+++ b/xenmgr/Vm/Actions.hs
@@ -777,16 +777,16 @@ createSnapshot disk encrypted = do
     when exists (removeFile newPath)
     if encrypted then createEnc path newPath else create path newPath
   where
-    create path newPath = do readProcess "vhd-util" ["snapshot", "-n", newPath, "-p", path] []
+    create path newPath = do readProcessOrDie "vhd-util" ["snapshot", "-n", newPath, "-p", path] []
                              info $ "newPath = " ++ newPath
                              return disk { diskPath = newPath }
-    createEnc path newPath = do readProcess "vhd-util" ["snapshot", "-n", newPath, "-p", path] []
+    createEnc path newPath = do readProcessOrDie "vhd-util" ["snapshot", "-n", newPath, "-p", path] []
                                 let keyname = head $ split '.' $ last $ split '/' newPath
                                 let keypath = "/config/platform-crypto-keys/" ++ keyname ++ ",aes-xts-plain,256.key"
                                 urandHandle <- openFile "/dev/urandom" ReadMode
                                 key <- B.hGet urandHandle 32
                                 B.writeFile keypath key
-                                readProcess "vhd-util" ["key", "-s", "-n", newPath, "-k", keypath] []
+                                readProcessOrDie "vhd-util" ["key", "-s", "-n", newPath, "-k", keypath] []
                                 hClose urandHandle
                                 info $ "newPath = " ++ newPath
                                 return disk { diskPath = newPath }

--- a/xenmgr/XenMgr/Connect/Xl.hs
+++ b/xenmgr/XenMgr/Connect/Xl.hs
@@ -68,6 +68,7 @@ import Vm.State
 import Tools.Misc as TM
 import Tools.XenStore
 import Tools.Log
+import Tools.Process
 import System
 import System.Cmd
 import System.Process
@@ -130,7 +131,7 @@ acpiState uuid = do
     case domid of
       "" -> return 5 --no domid indicates domain is off, so acpi state 5
       _  -> do
-              acpi_state <- readProcess "xl" ["acpi-state", domid] []
+              acpi_state <- readProcessOrDie "xl" ["acpi-state", domid] []
               let plain_acpi = (T.unpack (T.stripEnd (T.pack acpi_state)))
               case plain_acpi of
                 "-1" -> return 0  --If we have the domid but xl returns us -1 for acpi state, it's likely the domain
@@ -263,7 +264,7 @@ resumeFromFile uuid file delete paused =
 --Ask xl directly for the domid
 getDomainId :: Uuid -> IO String
 getDomainId uuid = do
-    domid <- readProcess "xl" ["uuid-to-domid", show uuid] []
+    domid <- readProcessOrDie "xl" ["uuid-to-domid", show uuid] []
     let plain_domid = (T.unpack (T.stripEnd (T.pack domid)))
     case plain_domid of
       "-1" -> return ("")

--- a/xenmgr/XenMgr/Diskmgr.hs
+++ b/xenmgr/XenMgr/Diskmgr.hs
@@ -37,5 +37,5 @@ createVhd :: Int -> IO FilePath
 createVhd sizeMB =
     do info $ "creating VHD (" ++ show sizeMB ++ "MB)"
        uuid <- uuidGen
-       spawnShell $ "vhd-util create -s " ++ show sizeMB ++ " -n /storage/disks/" ++ show uuid ++ ".vhd"
+       readProcessOrDie "vhd-util" [ "create", "-s", show sizeMB, "-n", "/storage/disks/" ++ show uuid ++ ".vhd" ] ""
        return $ "/storage/disks/" ++ show uuid ++ ".vhd"


### PR DESCRIPTION
OXT-1193

Signed-off-by: Jed <lejosnej@ainfosec.com>
(cherry picked from commit fe9768d33749c15c551ed4e0ee71c990e9aa8631)
Signed-off-by: Jed <lejosnej@ainfosec.com>