### PR TITLE
OXT-880: OE upgrade to pyro

### DIFF
--- a/upgrade-db/Migrations.hs
+++ b/upgrade-db/Migrations.hs
@@ -56,6 +56,7 @@ import qualified Migrations.M_32
 import qualified Migrations.M_33
 import qualified Migrations.M_34
 import qualified Migrations.M_35
+import qualified Migrations.M_36
 
 migrations :: [Migration]
 migrations = [ Migrations.M_1.migration
@@ -93,6 +94,7 @@ migrations = [ Migrations.M_1.migration
              , Migrations.M_33.migration
              , Migrations.M_34.migration
              , Migrations.M_35.migration
+             , Migrations.M_36.migration
              ]
 
 getMigrationFromVer :: Int -> Migration

--- a/upgrade-db/Migrations/M_36.hs
+++ b/upgrade-db/Migrations/M_36.hs
@@ -1,0 +1,50 @@
+--
+-- Copyright (c) 2018 Assured Information Security, Inc.
+-- 
+-- This program is free software; you can redistribute it and/or modify
+-- it under the terms of the GNU General Public License as published by
+-- the Free Software Foundation; either version 2 of the License, or
+-- (at your option) any later version.
+-- 
+-- This program is distributed in the hope that it will be useful,
+-- but WITHOUT ANY WARRANTY; without even the implied warranty of
+-- MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+-- GNU General Public License for more details.
+-- 
+-- You should have received a copy of the GNU General Public License
+-- along with this program; if not, write to the Free Software
+-- Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+--
+
+{-# LANGUAGE ForeignFunctionInterface #-}
+
+-- description: Pyro upgrade.
+-- Update sshd & sshd-v4v persistent configuration files.
+
+module Migrations.M_36 (migration) where
+
+import UpgradeEngine
+import Control.Monad
+import System.Directory
+
+migration = Migration {
+              sourceVersion = 36
+            , targetVersion = 37
+            , actions = act
+            }
+
+upgradeSshdPersistentConfig :: IO ()
+upgradeSshdPersistentConfig = do
+    sshEnabled <- doesFileExist "/config/etc/ssh/enabled"
+    when sshEnabled $ do
+        removeFile "/config/etc/ssh/enabled"
+        writeFile "/config/etc/ssh/sshd_not_to_be_run" ""
+
+    v4vEnabled <- doesFileExist "/config/etc/ssh/disable-v4v"
+    when v4vEnabled $ do
+        removeFile "/config/etc/ssh/disable-v4v"
+        writeFile "/config/etc/ssh/v4v_not_to_be_run" ""
+
+act :: IO ()
+act = do
+    upgradeSshdPersistentConfig

--- a/upgrade-db/Upgrade.hs
+++ b/upgrade-db/Upgrade.hs
@@ -40,7 +40,7 @@ import qualified Data.Text as T
 
 -- MODIFY THIS WHEN FORMAT CHANGES
 latestVersion :: Int
-latestVersion = 36
+latestVersion = 37
 ----------------------------------
 
 dbdRunning :: IO Bool

--- a/xenmgr/Vm/Pci.hs
+++ b/xenmgr/Vm/Pci.hs
@@ -398,7 +398,7 @@ initCache = PciCache <$> enumerateDevices
   where
     loadPciDatabase :: IO PciDatabase
     loadPciDatabase = do
-        pciDatabase <- loadFromDefaultFile
+        pciDatabase <- loadDefault
         case pciDatabase of
              Left _ ->
                  -- an unexpected error occurred while loading the PCI database.

--- a/xenmgr/XenMgr/Config.hs
+++ b/xenmgr/XenMgr/Config.hs
@@ -225,36 +225,37 @@ appSeamlessTrafficDefault = do
   return $ M.lookup "seamless-traffic-default" caps == Just "true"
 
 appGetEnableSsh :: Rpc Bool
-appGetEnableSsh = liftIO $ doesFileExist "/config/etc/ssh/enabled"
+appGetEnableSsh = liftIO $ not <$> doesFileExist "/config/etc/ssh/sshd_not_to_be_run"
 
 appSetEnableSsh :: Bool -> Rpc ()
-appSetEnableSsh False =
-    liftIO $ do
-      exist <- doesFileExist "/config/etc/ssh/enabled"
-      if exist then removeFile "/config/etc/ssh/enabled" else return ()
-      safeSpawnShell "/etc/init.d/sshd restart"
-      return ()
 appSetEnableSsh True =
     liftIO $ do
-      writeFile "/config/etc/ssh/enabled" ""
+      exist <- doesFileExist "/config/etc/ssh/sshd_not_to_be_run"
+      if exist then removeFile "/config/etc/ssh/sshd_not_to_be_run" else return ()
+      safeSpawnShell "/etc/init.d/sshd restart"
+      return ()
+
+appSetEnableSsh False =
+    liftIO $ do
+      writeFile "/config/etc/ssh/sshd_not_to_be_run" ""
       safeSpawnShell "/etc/init.d/sshd restart"
       return ()
 
 appGetEnableV4vSsh :: Rpc Bool
-appGetEnableV4vSsh = not <$> liftIO (doesFileExist "/config/etc/ssh/disable-v4v")
+appGetEnableV4vSsh = liftIO $ not <$> doesFileExist "/config/etc/ssh/v4v_not_to_be_run"
 
 appSetEnableV4vSsh :: Bool -> Rpc ()
-appSetEnableV4vSsh False =
-    liftIO $ do
-      writeFile "/config/etc/ssh/disable-v4v" ""
-      safeSpawnShell "/etc/init.d/sshd_v4v restart"
-      return ()
-
 appSetEnableV4vSsh True =
     liftIO $ do
-      exist <- doesFileExist "/config/etc/ssh/disable-v4v"
-      if exist then removeFile "/config/etc/ssh/disable-v4v" else return ()
-      safeSpawnShell "/etc/init.d/sshd_v4v restart"
+      exist <- doesFileExist "/config/etc/ssh/v4v_not_to_be_run"
+      if exist then removeFile "/config/etc/ssh/v4v_not_to_be_run" else return ()
+      safeSpawnShell "/etc/init.d/sshd-v4v restart"
+      return ()
+
+appSetEnableV4vSsh False =
+    liftIO $ do
+      writeFile "/config/etc/ssh/v4v_not_to_be_run" ""
+      safeSpawnShell "/etc/init.d/sshd-v4v restart"
       return ()
 
 appGetEnableDom0Networking :: Rpc Bool


### PR DESCRIPTION
- Use Zlib already available in DEPENDS instead of relying on a forked shell to read a static database;
- Add migration script to handle changes in `openssh` configuration.

# Dependencies:
See https://github.com/OpenXT/xenclient-oe/pull/830