### PR TITLE
xec-vm: fix suspend/resume to/from file

### DIFF
--- a/xenmgr/XenMgr/Connect/Xl.hs
+++ b/xenmgr/XenMgr/Connect/Xl.hs
@@ -286,14 +286,14 @@ suspendToFile :: Uuid -> FilePath -> IO ()
 suspendToFile uuid file =
     do
       domid    <- getDomainId uuid
-      exitCode <- system ("xl save " ++ domid ++ " " ++ file)
+      exitCode <- system ("xl save " ++ domid ++ " " ++ file ++ " " ++ configPath uuid)
       bailIfError exitCode "Error suspending to file."
 
 resumeFromFile :: Uuid -> FilePath -> Bool -> Bool -> IO ()
 resumeFromFile uuid file delete paused =
     do
       let p = if paused then "-p" else ""
-      _ <- system ("xl restore " ++ p ++ file)
+      _ <- system ("xl restore " ++ p ++ " " ++ configPath uuid ++ " " ++ file)
       if delete then removeFile file else return ()
 
 --Ask xl directly for the domid


### PR DESCRIPTION
With suspend and resume, xec-vm fails with the error:

   unable to retrieve domain configuration

Supplying the extra command parameter (the domain's xen config file)
to the underlying xl command fixes the issue.

Signed-off-by: Jafar Al-Gharaibeh <jafar@atcorp.com>