### PR TITLE
STABLE-8: xenmgr: remove snapshot disk key on shutdown

### DIFF
--- a/xenmgr/Vm/React.hs
+++ b/xenmgr/Vm/React.hs
@@ -283,6 +283,7 @@ maybeCleanupSnapshots = do
     let disks = vmcfgDisks config
     info $ "cleanupSnapshots disks = " ++ (show disks)
     sequence $ map removeIfExists $ map (++".snap.tmp.vhd") $ map diskPath disks
+    sequence $ map removeIfExists $ map (  (++",aes-xts-plain,256.key") . head . (split '.') ) $ map diskPath disks
     return ()
   where
     removeIfExists path = do


### PR DESCRIPTION
OXT-1243

Signed-off-by: Jed <lejosnej@ainfosec.com>
(cherry picked from commit a7eeaf358a6b85934b50d9bb5cf42703d9002908)
Signed-off-by: Jed <lejosnej@ainfosec.com>