### PR TITLE
STABLE-8: OXT-1384: Syncvm Flask label

### DIFF
--- a/templates/default/new-vm-sync
+++ b/templates/default/new-vm-sync
@@ -25,9 +25,7 @@
     "display": "none",
     "cmdline": "root=\/dev\/xvda1 xencons=hvc0",
     "kernel-extract": "\/boot\/bzImage",
-    "extra-xenvm": {
-      "0": "flask-label=system_u:system_r:syncvm_t"
-    },
+    "flask-label": "system_u:system_r:syncvm_t",
     "nic": {
       "0": {
         "id": "0",

--- a/upgrade-db/Migrations.hs
+++ b/upgrade-db/Migrations.hs
@@ -57,6 +57,7 @@ import qualified Migrations.M_33
 import qualified Migrations.M_34
 import qualified Migrations.M_35
 import qualified Migrations.M_36
+import qualified Migrations.M_38
 
 migrations :: [Migration]
 migrations = [ Migrations.M_1.migration
@@ -95,6 +96,7 @@ migrations = [ Migrations.M_1.migration
              , Migrations.M_34.migration
              , Migrations.M_35.migration
              , Migrations.M_36.migration
+             , Migrations.M_38.migration
              ]
 
 getMigrationFromVer :: Int -> Migration

--- a/upgrade-db/Migrations/M_37.hs
+++ b/upgrade-db/Migrations/M_37.hs
@@ -1,0 +1,1 @@
+-- Migration 37 does not exist in stable-8

--- a/upgrade-db/Migrations/M_38.hs
+++ b/upgrade-db/Migrations/M_38.hs
@@ -1,0 +1,41 @@
+--
+-- Copyright (c) 2012 Citrix Systems, Inc.
+-- Copyright (c) 2018 Jason Andryuk
+--
+-- This program is free software; you can redistribute it and/or modify
+-- it under the terms of the GNU General Public License as published by
+-- the Free Software Foundation; either version 2 of the License, or
+-- (at your option) any later version.
+--
+-- This program is distributed in the hope that it will be useful,
+-- but WITHOUT ANY WARRANTY; without even the implied warranty of
+-- MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+-- GNU General Public License for more details.
+--
+-- You should have received a copy of the GNU General Public License
+-- along with this program.  If not, see <https://www.gnu.org/licenses/>.
+--
+
+{-# LANGUAGE PatternGuards #-}
+
+module Migrations.M_38 (migration) where
+
+import UpgradeEngine
+
+migration = Migration {
+              sourceVersion = 37 -- skipping 38 not in stable-8
+            , targetVersion = 39
+            , actions = act
+            }
+
+act :: IO ()
+act = updateSyncvm
+
+updateSyncvm = xformVmJSON xform where
+  xform tree = case jsGet "/type" tree of
+    Just s | jsUnboxString s == "syncvm" -> modify tree
+    _ -> tree
+    where
+      modify = jsSet "/config/flask-label"
+                   (jsBoxString "system_u:system_r:syncvm_t") .
+               jsRm "/config/extra-xenvm/0"

--- a/upgrade-db/Upgrade.hs
+++ b/upgrade-db/Upgrade.hs
@@ -40,7 +40,7 @@ import qualified Data.Text as T
 
 -- MODIFY THIS WHEN FORMAT CHANGES
 latestVersion :: Int
-latestVersion = 37
+latestVersion = 39
 ----------------------------------
 
 dbdRunning :: IO Bool


### PR DESCRIPTION
This is the stable-8 version of https://github.com/OpenXT/manager/pull/123

The current syncvm template creates an un-bootable config. The old template passed the flask label directly to xenvm through extra-xenvm "flask-label". This worked for the xenvm-based system, but it broke with the XL conversion. "flask-label" is invalid in the XL config ("seclabel" should be used), so it throws an error about the legacy Python syntax.

The migration code hardcodes the syncvm_t flask label. Alternate labels will be clobbered, but this doesn't seem like a realistic case to handle.

This stable-8 version skips db version 38.  Migrations/M_37.hs is a placeholder empty file.  In the log output you see `update-db: Migrating 37 -> 39` skipping the intermediate version.