### PR TITLE
OXT-1431: Guest UEFI support

### DIFF
--- a/xenmgr/Vm/Actions.hs
+++ b/xenmgr/Vm/Actions.hs
@@ -114,6 +114,7 @@ module Vm.Actions
           , setVmTimerMode
           , setVmNestedHvm
           , setVmSerial
+          , setVmBios
           , setVmAutolockCdDrives
           , cleanupV4VDevice
           , EventHookFailMode(..)
@@ -1875,6 +1876,7 @@ setVmHpet uuid v = saveConfigProperty uuid vmHpet (v::Bool)
 setVmTimerMode uuid v = saveConfigProperty uuid vmTimerMode (v::String)
 setVmNestedHvm uuid v = saveConfigProperty uuid vmNestedHvm (v::Bool)
 setVmSerial uuid v = saveConfigProperty uuid vmSerial (v::String)
+setVmBios uuid v = saveConfigProperty uuid vmBios (v::String)
 
 -- set autolock flag on the vm xenstore tree, per cd device
 -- cd devices which have sticky bit are not subject to autolock ever

--- a/xenmgr/Vm/Config.hs
+++ b/xenmgr/Vm/Config.hs
@@ -80,6 +80,7 @@ module Vm.Config (
                 , vmTimerMode, vmTimerModeDefault
                 , vmNestedHvm
                 , vmSerial
+                , vmBios
                 ) where
 
 import Control.Arrow
@@ -454,6 +455,7 @@ vmNestedHvm = property "config.nestedhvm"
 vmSerial = property "config.serial"
 vmStubdomMemory = property "config.stubdom-memory"
 vmStubdomCmdline = property "config.stubdom-cmdline"
+vmBios = property "config.bios"
 
 -- Composite ones and lists
 vmExtraHvms    = property "config.extra-hvm"
@@ -847,6 +849,7 @@ miscSpecs cfg = do
           , ("stubdom_memory"  , vmStubdomMemory)   --OXT-1220: iomem and ioports should be reworked to support specifying multiple
           , ("iomem"           , vmPassthroughMmio) --ranges at a finer granularity. Few ways to implement, likely as a db-node with
           , ("ioports"         , vmPassthroughIo)   --each range as an entry beneath it, which is read and parsed during xl cfg generation.
+          , ("bios"            , vmBios)
           ]                                         --Remove this comment block when implemented.
 
       -- xl config handles certain options different than others (eg. quotes, brackets)
@@ -870,6 +873,7 @@ miscSpecs cfg = do
                                                            _  -> name ++ "=" ++ (wrapQuotes v)
                                              "seclabel" -> name ++ "=" ++ (wrapQuotes v)
                                              "boot"     -> name ++ "=" ++ (wrapQuotes v)
+                                             "bios"     -> name ++ "=" ++ (wrapQuotes v)
                                              "stubdom_cmdline" -> name ++ "=" ++ (wrapQuotes v)
                                              _          -> name ++ "=" ++ v) <$>
                                 readConfigProperty uuid prop

--- a/xenmgr/Vm/Queries.hs
+++ b/xenmgr/Vm/Queries.hs
@@ -123,6 +123,7 @@ module Vm.Queries
                , getVmTimerMode
                , getVmNestedHvm
                , getVmSerial
+               , getVmBios
                ) where
 
 import Data.String
@@ -1030,3 +1031,4 @@ getVmHpet uuid = readConfigPropertyDef uuid vmHpet vmHpetDefault
 getVmTimerMode uuid = readConfigPropertyDef uuid vmTimerMode vmTimerModeDefault
 getVmNestedHvm uuid = readConfigPropertyDef uuid vmNestedHvm False
 getVmSerial uuid = readConfigPropertyDef uuid vmSerial ""
+getVmBios uuid = readConfigPropertyDef uuid vmBios "seabios"

--- a/xenmgr/XenMgr/Expose/VmObject.hs
+++ b/xenmgr/XenMgr/Expose/VmObject.hs
@@ -651,6 +651,11 @@ implementationFor xm uuid = self where
   , comCitrixXenclientXenmgrVmSetSerial = restrict' $ setVmSerial uuid
   , comCitrixXenclientXenmgrVmUnrestrictedSetSerial = setVmSerial uuid
 
+  , comCitrixXenclientXenmgrVmGetBios = getVmBios uuid
+  , comCitrixXenclientXenmgrVmUnrestrictedGetBios = getVmBios uuid
+  , comCitrixXenclientXenmgrVmSetBios = restrict' $ setVmBios uuid
+  , comCitrixXenclientXenmgrVmUnrestrictedSetBios = setVmBios uuid
+
   } where
     stom "" = Nothing
     stom x  = Just x


### PR DESCRIPTION
BIOS option allows a user to choose between a guest using UEFI through OVMF, or traditional BIOS through SeaBios