### PR TITLE
OXT-1442: xenmgr: Use xl option rtc_timeoffset

### DIFF
--- a/xenmgr/Vm/Config.hs
+++ b/xenmgr/Vm/Config.hs
@@ -770,7 +770,7 @@ miscSpecs cfg = do
     where
       uuid = vmcfgUuid cfg
       -- omit if not specified
-      timeOffset = maybeToList . fmap ("time-offset="++) <$>
+      timeOffset = maybeToList . fmap ("rtc_timeoffset="++) <$>
         readConfigProperty uuid vmTimeOffset
       -- 16 meg if not specified
       videoram  = do


### PR DESCRIPTION
time-offset is not a valid XL option - XL thinks it is python.  A
similar XL option is rtc_timeoffset which sets the real time clock
offset in seconds.  I don't know what the old units were for this option
though.  xenvm did not seem to do anything with the value.

OXT-1442

Signed-off-by: Jason Andryuk <jandryuk@gmail.com>