### PR TITLE
Stubdom/PVH fixes

### DIFF
--- a/xenmgr/Vm/Actions.hs
+++ b/xenmgr/Vm/Actions.hs
@@ -919,8 +919,6 @@ bootVm config reboot
           exportVmSwitcherInfo uuid
           stubdom <- getVmStubdom uuid
           when stubdom $ updateStubDomainID uuid
-          stubdom_memory <- getVmStubdomMemory uuid
-          stubdom_cmdline <- getVmStubdomCmdline uuid
           applyVmFirewallRules uuid
           whenDomainID_ uuid $ \domid -> do
             liftIO $ xsWrite (domainXSPath domid ++ "/v4v-firewall-ready") "1"

--- a/xenmgr/Vm/Queries.hs
+++ b/xenmgr/Vm/Queries.hs
@@ -461,8 +461,11 @@ getVmUsbAutoPassthrough uuid = readConfigPropertyDef uuid vmUsbAutoPassthrough T
 getVmUsbControl :: Uuid -> Rpc Bool
 getVmUsbControl uuid = readConfigPropertyDef uuid vmUsbControl False
 
-getVmStubdom :: Uuid -> Rpc Bool
-getVmStubdom uuid = readConfigPropertyDef uuid vmStubdom False
+getVmStubdom :: (MonadRpc e m) => Uuid -> m Bool
+getVmStubdom uuid = do
+  vt <- getVmVirtType uuid
+  stub <- readConfigPropertyDef uuid vmStubdom False
+  return $ isHVM vt && stub
 
 getVmStubdomMemory :: Uuid -> Rpc Int
 getVmStubdomMemory uuid = readConfigPropertyDef uuid vmStubdomMemory 96


### PR DESCRIPTION
If a PVH domain has stubdom set to true, we hang waiting for a stubdom to appear.  Avoid this by making getVmStubdom only return true for HVMs.

The second commit removes some dead code.