### PR TITLE
xenmgr: ignore power btn event, just log it

### DIFF
--- a/xenmgr/XenMgr/PowerManagement.hs
+++ b/xenmgr/XenMgr/PowerManagement.hs
@@ -515,7 +515,7 @@ handleLidStateChanged closed = do
 
 handlePowerButtonPressed = do
     debug "PM: detected power button press event"
-    hostWhenIdleDoWithState HostShuttingDown $ executePmActionInternal ActionShutdown True
+    -- hostWhenIdleDoWithState HostShuttingDown $ executePmActionInternal ActionShutdown True
 
 handleSleepButtonPressed = do
     debug "PM: detected sleep button press event"


### PR DESCRIPTION
Signed-off-by: Jafar Al-Gharaibeh <jafar@atcorp.com>