### PR TITLE
OXT-1556: fix iso-hotswap

### DIFF
--- a/xenmgr/Vm/Config.hs
+++ b/xenmgr/Vm/Config.hs
@@ -655,7 +655,7 @@ diskSpec uuid d  = do
     -- convert hdX -> xvdX if hdtype is 'ahci'
     adjDiskDevice d hd_type =
       case hd_type of
-          "ahci" -> "xvd" ++ [(last $ diskDevice d)]
+          "ahci" -> if ((enumMarshall $ diskDeviceType d) == "cdrom") then (diskDevice d) else ("xvd" ++ [(last $ diskDevice d)])
           _      -> diskDevice d
 
 -- Next section: information about Network Interfaces


### PR DESCRIPTION
OXT-1556

For cdrom devices keep the name as 'hdc' because this is
used in iso-hotswap code.
AHCI currently doesn't support read-only devices, hence cdrom devices
cannot be AHCI emulated.

Signed-off-by: Mahantesh Salimath <salimathm@ainfosec.com>