### PR TITLE
xenmgr: Reconnect VIFs manually

### DIFF
--- a/xenmgr/Vm/Dm.hs
+++ b/xenmgr/Vm/Dm.hs
@@ -153,7 +153,8 @@ moveBackend t frontdomid id backdomid = do
              case (nicNet /= "") of
                  True   -> do liftIO $ Xl.removeNic uuid id backdomid
                               vifConnect uuid id nicNet frontdomid backdomid 30
-                 False  -> return ()
+                 False  -> do liftIO $ Xl.setNicBackendDom uuid id backdomid
+                              return ()
       -- Try to hook up the vif to the backend, retrying for specified timeout in seconds
       -- Rpc calls are also wrapped in their own retry block in case dbus isn't ready in the ndvm
       vifConnect uuid id nicNet frontdomid backdomid timeout =


### PR DESCRIPTION
We have domains providing network backends that do not run
network-slave.  In those cases, when the VM restarts, network-daemon
repeatedly tries to call network-slave resulting in eventual failure.
network-daemon: domain's 12 sytem bus is unresponsive: connect: invalid argument (Transport endpoint is not connected), retrying..

If we don't specify a "network" in the nic config, xenmgr won't try to
reconnect frontends.  Change that to instead call Xl.setNicBackendDom
when network is empty and bypass talking to network daemon/slave.  That
way we'll reconnect and avoid syslog messages.

Signed-off-by: Jason Andryuk <jandryuk@gmail.com>