### PR TITLE
Quiet rpc-proxy

### DIFF
--- a/rpc-proxy/Firewall.hs
+++ b/rpc-proxy/Firewall.hs
@@ -126,7 +126,7 @@ augmentRule (client, Just uuid, pmap) rule@Rule { match = match } = do
               Nothing -> do
                 -- query current property value via xenmgr access
                 v <- testVm (vmPath uuid) pname
-                info $ "assuming (" ++ show uuid ++ "," ++ pname ++ ") = " ++ show v
+                debug $ "assuming (" ++ show uuid ++ "," ++ pname ++ ") = " ++ show v
                 return ( Map.insert (uuid,pname) (cons v) pm
                        , cons v )
       

--- a/rpc-proxy/Msg/DBus.hs
+++ b/rpc-proxy/Msg/DBus.hs
@@ -97,6 +97,8 @@ incomingData sock =
     ) `E.catch` err
   where
     err :: E.SomeException -> IO LazyBS.ByteString
-    err x = do warn $ printf "%s on %s" (show x) (show sock)
+    err x = do _err $ E.fromException x
                return LazyBS.empty
-
+    _err (Just (EOF s)) = debug $ printf "%s on %s" (show (EOF s)) (show sock)
+    _err (Just ex) = warn $ printf "%s on %s" (show ex) (show sock)
+    _err Nothing = return ()

--- a/rpc-proxy/Msg/Json.hs
+++ b/rpc-proxy/Msg/Json.hs
@@ -148,8 +148,11 @@ incomingData sock =
     ) `E.catch` err
   where
     err :: E.SomeException -> IO BL.ByteString
-    err x = do warn $ printf "%s on %s" (show x) (show sock)
+    err x = do _err $ E.fromException x
                return BL.empty
+    _err (Just (EOF s)) = do debug $ printf "%s on %s" (show (EOF s)) (show sock)
+    _err (Just ex) = do warn $ printf "%s on %s" (show ex) (show sock)
+    _err Nothing = do return ()
 
 jmsgToJson :: JMsg -> JSValue
 jmsgToJson (JMsgReq m) = jreqToJson m


### PR DESCRIPTION
This PR changes lots of messages to debug priority which makes rpc-proxy less chatty in /var/log/messages.  They are at debug level, so rsyslog sees them and then chooses to ignore them with out default /etc/rsyslog.conf.

For a single message, it changes from
> rpc-proxy: incoming connection from domain 1, port 0x9e366f5e, fd is 10
> rpc-proxy: null byte received from incoming transport - setting up conversation
> rpc-proxy: authenticating client <v4v: 10> ArtefactSource {sourceDomainID = 1, sourceUuid = Just 00000000-0000-0000-0000-000000000002, sourceIsStubdom = False} rpc-proxy: auth: null byte sent to server
> rpc-proxy: auth done for <v4v: 10>
> rpc-proxy: starting forwarding <socket: 14> -> <v4v: 10>
> rpc-proxy: starting forwarding <v4v: 10> -> <socket: 14>
> rpc-proxy: assuming (00000000-0000-0000-0000-000000000002,domstore-read-access) = True
> rpc-proxy: assuming (00000000-0000-0000-0000-000000000002,domstore-write-access) = True
> rpc-proxy: assuming (00000000-0000-0000-0000-000000000002,usb-control) = False
> rpc-proxy: assuming (00000000-0000-0000-0000-000000000002,type) = "ndvm"
> rpc-proxy: <v4v: 10>: end of stream reached on <v4v: 10>
> rpc-proxy: stopping forwarding <v4v: 10> -> <socket: 14>
> rpc-proxy: <socket: 14>: end of stream reached on <socket: 14>
> rpc-proxy: stopping forwarding <socket: 14> -> <v4v: 10> 

to:
> rpc-proxy: incoming connection from domain 1, port 0x9e366f5e, fd is 10
> rpc-proxy: authenticating client <v4v: 10> ArtefactSource {sourceDomainID = 1, sourceUuid = Just 00000000-0000-0000-0000-000000000002, sourceIsStubdom = False}
