### PR TITLE
STABLE-9: xenmgr: Print the uuid during state checks

### DIFF
--- a/xenmgr/XenMgr/Connect/Xl.hs
+++ b/xenmgr/XenMgr/Connect/Xl.hs
@@ -462,7 +462,7 @@ state uuid =
         maybe_state <- xsRead ("/state/" ++ show uuid ++ "/state")
         case maybe_state of
           Just state -> do
-                          info $ "active vms, state = " ++ show state
+                          info $ "active vm " ++ show uuid ++ " state = " ++ show state
                           return $ stateFromStr state
           Nothing    -> return $ stateFromStr "shutdown"
 


### PR DESCRIPTION
Stable-9 version of https://github.com/OpenXT/manager/pull/142

"active vms" isn't informative.  Add the uuid to the output.

Signed-off-by: Jason Andryuk <jandryuk@gmail.com>
(cherry picked from commit 7341f9040818c705fa2abdfcf316dd723198f597)