### PR TITLE
xenmgr: Add xl trigger power to HVM shutdown

### DIFF
--- a/xenmgr/XenMgr/Connect/Xl.hs
+++ b/xenmgr/XenMgr/Connect/Xl.hs
@@ -185,6 +185,7 @@ shutdown uuid =
                       case exitCode of
                         ExitSuccess   -> return ()
                         _             -> do xsWrite ("/local/domain/" ++ domid ++ "/control/hvm-shutdown") "poweroff"
+                                            _ <- system ("xl trigger " ++ domid ++ " power")
                                             _ <- system ("xl shutdown -F -w " ++ domid)
                                             return ()
         Nothing -> do system ("xl shutdown -c -w " ++ domid)


### PR DESCRIPTION
The QEMU ACPI hvm-shutdown and hvm-power-button xenstore entries don't
always work.  On the QEMU side, it looks like the IRQ is raised and the
ACPI_SLP_BIT is cleared, but the guest doesn't shutdown.  `xl shutdown
-F -w` just hangs.

Manually running `xl trigger DomU power` after that seems to trigger the
shutdown, so just have xenmgr make that invocation.

Signed-off-by: Jason Andryuk <jandryuk@gmail.com>