### PR TITLE
xenmgr: Use /dev/hvc0 for measurement failure messages

### DIFF
--- a/xenmgr/Vm/React.hs
+++ b/xenmgr/Vm/React.hs
@@ -159,7 +159,7 @@ measuresR xm_context = mkReact f where
   f (VmMeasurementFailure fpath expected actual)
     = do action <- liftRpc getMeasureFailAction
          let msg = printf "measuring of file %s FAILED. Expected checksum: %x actual %x. Performing %s" fpath expected actual (show action)
-         liftIO (warn msg >> writeFile "/dev/xvc0" (msg++"\n"))
+         liftIO (warn msg >> writeFile "/dev/hvc0" (msg++"\n"))
          runXM xm_context (executePmAction action)
   f _
     = return ()


### PR DESCRIPTION
/dev/xvc0 doesn't exist on para-virt Xen kernels.  Use /dev/hvc0 to
actually print out the message.

Signed-off-by: Jason Andryuk <jandryuk@gmail.com>