### PR TITLE
xenmgr: avoid leaking FDs to run scripts

### DIFF
--- a/xenmgr/Vm/Actions.hs
+++ b/xenmgr/Vm/Actions.hs
@@ -301,7 +301,10 @@ runEventScript failmode vm get_hooks args =
          return ()
     exec path =
       -- stderr redirected to warn, stdout to info
-      runInteractiveProcess path args Nothing Nothing >>= \ (_, stdout, stderr, h) ->
+      createProcess (proc path args){ std_in = CreatePipe,
+                                      std_out = CreatePipe,
+                                      std_err = CreatePipe,
+                                      close_fds = True } >>= \ (_, Just stdout, Just stderr, h) ->
           do hSetBuffering stdout NoBuffering
              hSetBuffering stderr NoBuffering
              contents_mv <- newEmptyMVar


### PR DESCRIPTION
runInteractiveProcess doesn't touch FDs, so it leaks them out into the
wild.  This is seen by AVCs for /etc/xenclient.conf and a socket or pipe
when a shell script runs.

Switch to createProcess so we can set close_fds = True and avoid the
leakage.

Signed-off-by: Jason Andryuk <jandryuk@gmail.com>