### PR TITLE
S9: xenmgr: Fix Power control affects VM and Host

### DIFF
--- a/xenmgr/Vm/React.hs
+++ b/xenmgr/Vm/React.hs
@@ -208,7 +208,8 @@ powerlinkR xm get_shr =
                             liftIO (Xl.resumeFromSleep (vm_uuid vm))
                             return ()
       shutdown vm      = do reason <- runVm vm get_shr
-                            when ( reason /= Restarting ) $
+                            debug $ "Power Link: shutdown hook reason " ++ show reason
+                            when ( reason == Halt ) $
                               info "Power Link: shutdown" >> hostShutdown
 
 logStatesR = mkReact f where


### PR DESCRIPTION
This is the Stable-9 version of https://github.com/OpenXT/manager/pull/152

When a VM was set for "Power control affects VM and host", I was seeing
a guest reboot end up shutting down the host.  When "shutdown vm" is
called, the shutdown reason reason was observed to be Halt or Reboot - I
haven't seen Restarting.  Check for Halt and shutdown the host in that
case.  That could miss the AcpiPowerOff reason, but that has not been
seen in practice.

Signed-off-by: Jason Andryuk <jandryuk@gmail.com>
(cherry picked from commit 20c7e134857ec71a68009c2575f2f8cbe67f2847)