### PR TITLE
[OXT-1356] Set stubdom backend to "tap" when given a rawdisk

### DIFF
--- a/xenmgr/Vm/Config.hs
+++ b/xenmgr/Vm/Config.hs
@@ -652,7 +652,7 @@ diskSpec uuid d  = do
     cdType stubdom d =
       case (enumMarshall $ diskDeviceType d) of
           "cdrom" -> if stubdom then "backendtype=tap" else "backendtype=phy"
-          _       -> if (enumMarshall $ diskType d) == "phy" then "backendtype=phy" else "backendtype=tap"
+          _       -> if (enumMarshall $ diskType d) == "phy" && stubdom == False then "backendtype=phy" else "backendtype=tap"
     fileToRaw typ = if typ == "file" || typ == "phy" then "raw" else typ
     -- convert hdX -> xvdX if hdtype is 'ahci'
     adjDiskDevice d hd_type =


### PR DESCRIPTION
Attaching or having a rawdisk with a stubdom ends up timing out Qemu.
Checking for this scenario when parsing the configuration file set the
backend to "tap".