### PR TITLE
[OXT-1356] STABLE-9: Set stubdom backend to "tap" when given a rawdisk

### DIFF
--- a/xenmgr/Vm/Config.hs
+++ b/xenmgr/Vm/Config.hs
@@ -650,7 +650,7 @@ diskSpec uuid d  = do
     cdType stubdom d =
       case (enumMarshall $ diskDeviceType d) of
           "cdrom" -> if stubdom then "backendtype=tap" else "backendtype=phy"
-          _       -> if (enumMarshall $ diskType d) == "phy" then "backendtype=phy" else "backendtype=tap"
+          _       -> if (enumMarshall $ diskType d) == "phy" && stubdom == False then "backendtype=phy" else "backendtype=tap"
     fileToRaw typ = if typ == "file" || typ == "phy" then "raw" else typ
     -- convert hdX -> xvdX if hdtype is 'ahci'
     adjDiskDevice d hd_type =


### PR DESCRIPTION
Attaching or having a rawdisk with a stubdom ends up timing out Qemu.
Checking for this scenario when parsing the configuration file set the
backend to "tap".

Signed-off-by: Tim Konick <konickt@ainfosec.com>
(cherry picked from commit f20ddbc6831746c1cc4467959c7458ac12955bc1)
Signed-off-by: Tim Konick <konickt@ainfosec.com>