### PR TITLE
STABLE-9: OXT-1582: [ahci] Force ide for hdtype for Linux hvm guests

### DIFF
--- a/xenmgr/Vm/Config.hs
+++ b/xenmgr/Vm/Config.hs
@@ -572,7 +572,7 @@ getXlConfig cfg =
                  let dm_args = case virt of
                                  HVM -> ["device_model_version='qemu-xen'"]
                                  _   -> []
-                 let hdtype = ["hdtype='" ++ hd_type ++ "'"]
+                 let hdtype = ["hdtype='" ++ (if vmcfgOs cfg == Linux && isHvm cfg then "ide" else hd_type) ++ "'"]
 
                  return $ [ "uuid='" ++ (show uuid) ++ "'"
                           , "vnc=0"


### PR DESCRIPTION
  AHCI xen unplug is not supported in QEMU or Xen yet, only IDE
  is. For most modern hvm Linux guests, the PV disk driver blkfront
  will compiled into the kernel by default and loaded, making a choice
  between IDE or AHCI emulation irrelevant, since the guest will use the
  PV disk driver.  If we tell QEMU we're IDE, at least the unplug path
  through piix.c will unplug the extra disk to prevent user confusion.

  OXT-1582

Signed-off-by: Chris <rogersc@ainfosec.com>
(cherry picked from commit 19bd14eff9f13d3612e2bb26b52f7b694005bfba)