### PR TITLE
STABLE-9: OXT-1582: [linux] Use ide instead of AHCI

### DIFF
--- a/templates/default/new-vm-linux
+++ b/templates/default/new-vm-linux
@@ -26,7 +26,7 @@
     "display": "none",
     "boot": "cd",
     "flask-label": "system_u:system_r:hvm_guest_t",
-    "hdtype": "ahci",
+    "hdtype": "ide",
     "disk": {
       "0": {
         "path": "\/storage\/isos\/xc-tools.iso",


### PR DESCRIPTION
  For Linux guests, with AHCI emulation there will be 2 disks
  shown to the guest; the AHCI emulated and the PV blkfront which
  is compiled into most modern Linux distros. Have Linux guests
  use IDE emulation so the Xen/Qemu unplug path can remove the
  emulated disk to avoid confusing the user. AHCI vs IDE doesn't
  matter because the PV driver will be used anyway.

  OXT-1582

Signed-off-by: Chris <rogersc@ainfosec.com>
(cherry picked from commit 159a874bcaa46f15246e5ea30ddbfd354a050da5)