### PR TITLE
OXT-1647: templates: Make UIVM default to PVH.

### DIFF
--- a/templates/default/service-uivm
+++ b/templates/default/service-uivm
@@ -63,7 +63,7 @@
     "debug": "true",
     "pae": "true",
     "acpi": "true",
-    "virt-type": "pv",
+    "virt-type": "pvh",
     "apic": "true",
     "nx": "true",
     "vkbd" : "true",


### PR DESCRIPTION
Change `virt-type` from `pv` to `pvh`.