### PR TITLE
templates: Switch xencons to console

### DIFF
--- a/templates/default/new-vm-sync
+++ b/templates/default/new-vm-sync
@@ -23,7 +23,7 @@
     "argo": "true",
     "memory": "256",
     "display": "none",
-    "cmdline": "root=\/dev\/xvda1 xencons=hvc0",
+    "cmdline": "root=\/dev\/xvda1 console=hvc0",
     "kernel-extract": "\/boot\/bzImage",
     "flask-label": "system_u:system_r:syncvm_t",
     "nic": {

--- a/templates/default/service-uivm
+++ b/templates/default/service-uivm
@@ -72,7 +72,7 @@
     "memory-min": "192",
     "memory": "256",
     "display": "none",
-    "cmdline": "root=\/dev\/xvda1 xencons=hvc0",
+    "cmdline": "root=\/dev\/xvda1 console=hvc0",
     "kernel-extract": "\/boot\/bzImage",
     "flask-label": "system_u:system_r:uivm_t",
     "disk": {


### PR DESCRIPTION
xencons is the old option name which has no affect on modern linux.  Use
console to specify the console.

This will restore console output in /var/log/messages from uivm and
syncvm.

Signed-off-by: Jason Andryuk <jandryuk@gmail.com>