### PR TITLE
S9: OXT-1684: upgrade-db: Update db-version to apply Migration_40

### DIFF
--- a/upgrade-db/Upgrade.hs
+++ b/upgrade-db/Upgrade.hs
@@ -40,7 +40,7 @@ import qualified Data.Text as T
 
 -- MODIFY THIS WHEN FORMAT CHANGES
 latestVersion :: Int
-latestVersion = 40
+latestVersion = 41
 ----------------------------------
 
 dbdRunning :: IO Bool


### PR DESCRIPTION
Stable-9 version of https://github.com/OpenXT/manager/pull/173

Upgrades are not handling the v4v->argo conversion since Migration_40 is
not being run.  We need to set latestVersion to 41 to run the
migrations.

NDVM & UIVM don't have a problem since their configs are injected from
on-disk copies already updated for argo at boot time.  It's only other
existing VMs with v4v rules that need updating.

Signed-off-by: Jason Andryuk <jandryuk@gmail.com>
(cherry picked from commit 551206c0da0ba6adc03356005cecfc1a2c7442ba)