### PR TITLE
OXT-1686 : create-ndvm: enable HAP/EPT/SLAT

### DIFF
--- a/templates/default/new-vm-ndvm-hvm
+++ b/templates/default/new-vm-ndvm-hvm
@@ -40,6 +40,7 @@
     "acpi": "true",
     "virt-type": "hvm",
     "apic": "true",
+    "hap": "true",
     "nx": "true",
     "argo": "true",
     "memory": "192",


### PR DESCRIPTION
For increased security, enable HAP (hardware-assisted paging) SLAT
(Second Level Address Translation) instead of Xen shadow page tables.
Also known as:

  - Intel EPT (Extended Page Tables)
  - AMD NPT (Nested Page Tables)

OXT-1686

Signed-off-by: Rich Persaud <rich.persaud@baesystems.com>

Requires https://github.com/OpenXT/xenclient-oe/pull/1339