### PR TITLE
OXT-1752 : templates: disable Argo for user VMs

### DIFF
--- a/templates/default/new-vm
+++ b/templates/default/new-vm
@@ -20,7 +20,7 @@
     "viridian": "true",
     "hap": "true",
     "nx": "true",
-    "argo": "true",
+    "argo": "false",
     "sound": "ac97",
     "memory": "2048",
     "display": "none",

--- a/templates/default/new-vm-linux
+++ b/templates/default/new-vm-linux
@@ -20,7 +20,7 @@
     "viridian": "false",
     "hap": "true",
     "nx": "true",
-    "argo": "true",
+    "argo": "false",
     "sound": "ac97",
     "memory": "1024",
     "display": "none",

--- a/templates/default/new-vm-windows8
+++ b/templates/default/new-vm-windows8
@@ -21,7 +21,7 @@
     "viridian": "true",
     "hap": "true",
     "nx": "true",
-    "argo": "true",
+    "argo": "false",
     "sound": "ac97",
     "memory": "2048",
     "display": "none",

--- a/templates/default/new-vm-xp
+++ b/templates/default/new-vm-xp
@@ -20,7 +20,7 @@
     "viridian": "true",
     "hap": "true",
     "nx": "true",
-    "argo": "true",
+    "argo": "false",
     "sound": "ac97",
     "memory": "1024",
     "display": "none",


### PR DESCRIPTION
Since Argo is primarily used by service VMs, it is disabled by XSM
for guest VMs.  When enabled in the VM config file, Argo causes an
unknown device to appear in Windows Device Manager.  Disable argo in
VM config, to avoid alarming guest monitoring agents.

OXT-1752

Signed-off-by: Rich Persaud <rich.persaud@baesystems.com>