### PR TITLE
vglass: deprecate surfman logics and wire up vglass

### DIFF
--- a/apptool/samples/uivm.ovf
+++ b/apptool/samples/uivm.ovf
@@ -49,9 +49,6 @@
 	    <xci:RpcRule>allow destination com.citrix.xenclient.input</xci:RpcRule>
 	    <xci:RpcRule>allow destination com.citrix.xenclient.usbdaemon</xci:RpcRule>
 	    <xci:RpcRule>allow destination com.citrix.xenclient.updatemgr</xci:RpcRule>
-	    <xci:RpcRule>allow destination com.citrix.xenclient.surfman interface com.citrix.xenclient.surfman member increase_brightness</xci:RpcRule>
-	    <xci:RpcRule>allow destination com.citrix.xenclient.surfman interface com.citrix.xenclient.surfman member decrease_brightness</xci:RpcRule>
-	    <xci:RpcRule>allow destination com.citrix.xenclient.surfman interface com.citrix.xenclient.surfman member display_image</xci:RpcRule>
 	    <xci:RpcRule>allow destination com.citrix.xenclient.networkdaemon</xci:RpcRule>
 	  </xci:RpcFirewall>
 

--- a/templates/default/new-vm
+++ b/templates/default/new-vm
@@ -37,6 +37,7 @@
       }
     },
     "vcpus": "1",
-    "qemu-dm-path": "\/usr\/sbin\/svirt-interpose"
+    "qemu-dm-path": "\/usr\/sbin\/svirt-interpose",
+    "vglass-enabled": "true"
   }
 }

--- a/templates/default/new-vm-linux
+++ b/templates/default/new-vm-linux
@@ -37,6 +37,7 @@
       }
     },
     "vcpus": "1",
-    "qemu-dm-path": "\/usr\/sbin\/svirt-interpose"
+    "qemu-dm-path": "\/usr\/sbin\/svirt-interpose",
+    "vglass-enabled": "true"
   }
 }

--- a/templates/default/new-vm-windows8
+++ b/templates/default/new-vm-windows8
@@ -38,6 +38,7 @@
       }
     },
     "vcpus": "1",
-    "qemu-dm-path": "\/usr\/sbin\/svirt-interpose"
+    "qemu-dm-path": "\/usr\/sbin\/svirt-interpose",
+    "vglass-enabled": "true"
   }
 }

--- a/templates/default/new-vm-windows8
+++ b/templates/default/new-vm-windows8
@@ -39,6 +39,7 @@
     },
     "vcpus": "1",
     "qemu-dm-path": "\/usr\/sbin\/svirt-interpose",
-    "vglass-enabled": "true"
+    "vglass-enabled": "true",
+    "vkbd": "true"
   }
 }

--- a/templates/default/new-vm-xp
+++ b/templates/default/new-vm-xp
@@ -37,6 +37,7 @@
       }
     },
     "vcpus": "1",
-    "qemu-dm-path": "\/usr\/sbin\/svirt-interpose"
+    "qemu-dm-path": "\/usr\/sbin\/svirt-interpose",
+    "vglass-enabled": "true"
   }
 }

--- a/templates/default/service-uivm
+++ b/templates/default/service-uivm
@@ -64,7 +64,6 @@
     "apic": "true",
     "nx": "true",
     "vkbd" : "true",
-    "vfb" : "false",
     "argo" : "true",
     "memory-min": "192",
     "memory": "256",

--- a/templates/default/service-uivm
+++ b/templates/default/service-uivm
@@ -95,6 +95,7 @@
         "devtype": "disk"
       }
     },
-    "qemu-dm-path": "\/usr\/sbin\/svirt-interpose"
+    "qemu-dm-path": "\/usr\/sbin\/svirt-interpose",
+    "vglass-enabled": "true"
   }
 }

--- a/templates/default/service-uivm
+++ b/templates/default/service-uivm
@@ -64,7 +64,7 @@
     "apic": "true",
     "nx": "true",
     "vkbd" : "true",
-    "vfb" : "true",
+    "vfb" : "false",
     "argo" : "true",
     "memory-min": "192",
     "memory": "256",

--- a/templates/default/service-uivm
+++ b/templates/default/service-uivm
@@ -44,9 +44,6 @@
       "19": "allow destination com.citrix.xenclient.input",
       "20": "allow destination com.citrix.xenclient.usbdaemon",
       "21": "allow destination com.citrix.xenclient.updatemgr",
-      "22": "allow destination com.citrix.xenclient.surfman interface com.citrix.xenclient.surfman member increase_brightness",
-      "23": "allow destination com.citrix.xenclient.surfman interface com.citrix.xenclient.surfman member decrease_brightness",
-      "24": "allow destination com.citrix.xenclient.surfman interface com.citrix.xenclient.surfman member display_image",
       "25": "allow destination com.citrix.xenclient.networkdaemon",
       "26": "deny destination com.citrix.xenclient.xenmgr interface com.citrix.xenclient.xenmgr.config member Set",
       "27": "allow destination com.citrix.xenclient.xcpmd interface com.citrix.xenclient.xcpmd"

--- a/xenmgr/Vm/Actions.hs
+++ b/xenmgr/Vm/Actions.hs
@@ -913,19 +913,6 @@ bootVm config reboot
       --      liftIO $ xsWrite (xsp domid ++ "/bios-strings/xenvendor-product") "OpenXT 5.0.0"
        --     liftIO $ xsWrite (xsp domid ++ "/bios-strings/xenvendor-seamless-hint") "0"
 
-      --Changes to surfman/inputserver moved these calls into xenvm. With xenvm removal, it's easier to call
-      --them from Xenmgr.
-      surfmanDbusCalls uuid =
-          whenDomainID_ uuid $ \domid -> do
-            rpcCallOnce (Xl.xlSurfmanDbus uuid "set_pv_display" [toVariant $ (read (show domid) :: Int32), toVariant $ ""])
-            rpcCallOnce (Xl.xlSurfmanDbus uuid "set_visible" [toVariant $ (read (show domid) :: Int32), toVariant $ (0 :: Int32), toVariant $ False])
-            return ()
-
-      inputDbusCalls uuid =
-          whenDomainID_ uuid $ \domid -> do
-            rpcCallOnce (Xl.xlInputDbus uuid "attach_vkbd" [toVariant $ (read (show domid):: Int32) ])
-            return ()
-
       handleCreationPhases :: XM ()
       handleCreationPhases = do
         waitForVmInternalState uuid CreatingDevices Running 30
@@ -959,11 +946,6 @@ bootVm config reboot
             liftIO $ xsWrite backendNode (show domid)
             liftIO $ xsChmod backendNode "r0"
 
-          vfb_enabled <- getVmVfb uuid
-          when vfb_enabled $ surfmanDbusCalls uuid
-
-          vkb_enabled <- getVmVkbd uuid
-          when vkb_enabled $ inputDbusCalls uuid
           info $ "done pre-dm setup for " ++ show uuid
          
         waitForVmInternalState uuid Created Running 60

--- a/xenmgr/Vm/Actions.hs
+++ b/xenmgr/Vm/Actions.hs
@@ -120,6 +120,22 @@ module Vm.Actions
           , setVmAutolockCdDrives
           , setVmHdType
           , cleanupArgoDevice
+          , setVmDisplayHandlerStrict
+          , setVmLongForm
+          , setVmShortForm
+          , setVmTextColor
+          , setVmDomainColor
+          , setVmBorderWidth
+          , setVmBorderHeight
+          , setVmMosaicVmEnabled
+          , setVmVglassEnabled
+          , setVmMosaicMode
+          , setVmWindowedX
+          , setVmWindowedY
+          , setVmWindowedW
+          , setVmWindowedH
+          , setVmPrimaryDomainColor
+          , setVmSecondaryDomainColor
           , EventHookFailMode(..)
           ) where
 
@@ -1839,6 +1855,22 @@ setVmNestedHvm uuid v = saveConfigProperty uuid vmNestedHvm (v::Bool)
 setVmSerial uuid v = saveConfigProperty uuid vmSerial (v::String)
 setVmBios uuid v = saveConfigProperty uuid vmBios (v::String)
 setVmHdType uuid v = saveConfigProperty uuid vmHdType (v::String)
+setVmDisplayHandlerStrict uuid v = saveConfigProperty uuid vmDisplayHandlerStrict (v::Bool)
+setVmLongForm uuid v = saveConfigProperty uuid vmLongForm (v::String)
+setVmShortForm uuid v = saveConfigProperty uuid vmShortForm (v::String)
+setVmTextColor uuid v = saveConfigProperty uuid vmTextColor (v::String)
+setVmDomainColor uuid v = saveConfigProperty uuid vmDomainColor (v::String)
+setVmBorderWidth uuid v = saveConfigProperty uuid vmBorderWidth (v::Int)
+setVmBorderHeight uuid v = saveConfigProperty uuid vmBorderHeight (v::Int)
+setVmMosaicVmEnabled uuid v = saveConfigProperty uuid vmMosaicVmEnabled (v::Bool)
+setVmVglassEnabled uuid v = saveConfigProperty uuid vmVglassEnabled (v::Bool)
+setVmMosaicMode uuid v = saveConfigProperty uuid vmMosaicMode (v::Int)
+setVmWindowedX uuid v = saveConfigProperty uuid vmWindowedX (v::Int)
+setVmWindowedY uuid v = saveConfigProperty uuid vmWindowedY (v::Int)
+setVmWindowedW uuid v = saveConfigProperty uuid vmWindowedW (v::Int)
+setVmWindowedH uuid v = saveConfigProperty uuid vmWindowedH (v::Int)
+setVmPrimaryDomainColor uuid v = saveConfigProperty uuid vmPrimaryDomainColor (v::String)
+setVmSecondaryDomainColor uuid v = saveConfigProperty uuid vmSecondaryDomainColor (v::String)
 
 -- set autolock flag on the vm xenstore tree, per cd device
 -- cd devices which have sticky bit are not subject to autolock ever

--- a/xenmgr/Vm/Actions.hs
+++ b/xenmgr/Vm/Actions.hs
@@ -106,7 +106,6 @@ module Vm.Actions
           , setVmReady
           , setVmProvidesDefaultNetworkBackend
           , setVmVkbd
-          , setVmVfb
           , setVmArgo
           , setVmRestrictDisplayDepth
           , setVmRestrictDisplayRes
@@ -749,7 +748,6 @@ withPreCreationState uuid f =
 xsp domid = "/local/domain/" ++ show domid
 xsp_dom0  = "/local/domain/0"
 argoBack domid = "/backend/argo/" ++ show domid ++ "/0"
-vfbBack domid = "/backend/vfb/" ++ show domid ++ "/0"
 
 setupArgoDevice uuid =
   whenDomainID_ uuid $ \domid -> liftIO $ do
@@ -1843,7 +1841,6 @@ setVmDownloadProgress uuid v = do
   notifyVmTransferChanged uuid  
 setVmReady uuid v = saveConfigProperty uuid vmReady (v::Bool)
 setVmVkbd uuid v = saveConfigProperty uuid vmVkbd (v::Bool)
-setVmVfb uuid v = saveConfigProperty uuid vmVfb (v::Bool)
 setVmArgo uuid v = saveConfigProperty uuid vmArgo (v::Bool)
 setVmRestrictDisplayDepth uuid v = saveConfigProperty uuid vmRestrictDisplayDepth (v::Bool)
 setVmRestrictDisplayRes uuid v = saveConfigProperty uuid vmRestrictDisplayRes (v::Bool)

--- a/xenmgr/Vm/Config.hs
+++ b/xenmgr/Vm/Config.hs
@@ -20,7 +20,6 @@
 module Vm.Config (
                   ConfigProperty
 
-                , diagnose
                 , amtPtActive
 
                   -- read / write / check for existence of config properties
@@ -523,12 +522,6 @@ readConfigPropertyDef uuid p def =
     fromMaybe def <$> readConfigProperty uuid p
 
 type Problem = String
-
--- Find problems with config if any
-diagnose :: VmConfig -> [Problem]
-diagnose cfg
-    | vmcfgGraphics cfg == HDX, not (vmcfgPvAddons cfg) = [ "VM has HDX enabled, but PV addons are not installed" ]
-    | otherwise = [ ]
 
 isHvm :: VmConfig -> Bool
 isHvm cfg = vmcfgVirtType cfg == HVM

--- a/xenmgr/Vm/Config.hs
+++ b/xenmgr/Vm/Config.hs
@@ -811,6 +811,7 @@ miscSpecs cfg = do
     nested_ <- nested
     dm_override_ <- liftRpc dm_override
     dm_display_ <- liftRpc dm_display
+    vkb_ <- vkb
     extra_hvms <- readConfigPropertyDef uuid vmExtraHvms []
     acpi_table_ <- liftIO $ acpi_table
 
@@ -826,6 +827,7 @@ miscSpecs cfg = do
         ++ nested_
         ++ dm_override_
         ++ dm_display_
+        ++ vkb_
         ++ acpi_table_
     where
       uuid = vmcfgUuid cfg
@@ -880,6 +882,11 @@ miscSpecs cfg = do
              "none"  -> return ["vga='stdvga'"]
              ""      -> return ["vga='stdvga'"]
              d       -> return ["vga='stdvga'", "dm_display='" ++ d ++ "'"]
+
+      vkb = readConfigPropertyDef uuid vmVkbd False >>=
+                \ v -> if v then return ["vkb=['backend-type=linux']"]
+                            else return []
+
       -- Other config keys taken directly from .config subtree which we delegate directly
       -- to xenvm
       passToXenvmProperties =
@@ -892,7 +899,6 @@ miscSpecs cfg = do
           , ("extra"           , vmCmdLine)
           , ("vcpus"           , vmVcpus)
           , ("hap"             , vmHap)
-          , ("vkb"             , vmVkbd)
           , ("vfb"             , vmVfb)
           , ("seclabel"        , vmFlaskLabel)
           , ("init_seclabel"   , vmInitFlaskLabel)

--- a/xenmgr/Vm/Config.hs
+++ b/xenmgr/Vm/Config.hs
@@ -65,7 +65,7 @@ module Vm.Config (
                 , vmXciCpuidSignature
                 , vmS3Mode
                 , vmS4Mode
-                , vmVsnd, vmVkbd, vmVfb, vmArgo
+                , vmVsnd, vmVkbd, vmArgo
                 , vmRealm
                 , vmSyncUuid
                 , vmIcbinnPath
@@ -472,7 +472,6 @@ vmQemuDmPath = property "config.qemu-dm-path"
 vmQemuDmTimeout = property "config.qemu-dm-timeout"
 vmVsnd = property "config.vsnd"
 vmVkbd = property "config.vkbd"
-vmVfb = property "config.vfb"
 vmArgo = property "config.argo"
 vmHpet = property "config.hpet"
 vmHpetDefault = True
@@ -899,7 +898,6 @@ miscSpecs cfg = do
           , ("extra"           , vmCmdLine)
           , ("vcpus"           , vmVcpus)
           , ("hap"             , vmHap)
-          , ("vfb"             , vmVfb)
           , ("seclabel"        , vmFlaskLabel)
           , ("init_seclabel"   , vmInitFlaskLabel)
           , ("device_model_stubdomain_seclabel", vmStubdomFlaskLabel)

--- a/xenmgr/Vm/Config.hs
+++ b/xenmgr/Vm/Config.hs
@@ -82,6 +82,22 @@ module Vm.Config (
                 , vmSerial
                 , vmBios
                 , vmHdType
+                , vmDisplayHandlerStrict
+                , vmLongForm
+                , vmShortForm
+                , vmTextColor
+                , vmDomainColor
+                , vmBorderWidth
+                , vmBorderHeight
+                , vmMosaicVmEnabled
+                , vmVglassEnabled
+                , vmMosaicMode
+                , vmWindowedX
+                , vmWindowedY
+                , vmWindowedW
+                , vmWindowedH
+                , vmPrimaryDomainColor
+                , vmSecondaryDomainColor
                 ) where
 
 import Control.Arrow
@@ -464,6 +480,22 @@ vmTimerMode = property "config.timer-mode"
 vmTimerModeDefault = "no_delay_for_missed_ticks"
 vmNestedHvm = property "config.nestedhvm"
 vmSerial = property "config.serial"
+vmDisplayHandlerStrict = property "config.display-handler-strict"
+vmLongForm = property "config.long-form"
+vmShortForm = property "config.short-form"
+vmTextColor = property "config.text-color"
+vmDomainColor = property "config.domain-color"
+vmBorderWidth = property "config.border-width"
+vmBorderHeight = property "config.border-height"
+vmMosaicVmEnabled = property "config.mosaic-vm-enabled"
+vmVglassEnabled = property "config.vglass-enabled"
+vmMosaicMode = property "config.mosaic-mode"
+vmWindowedX = property "config.windowed-x"
+vmWindowedY = property "config.windowed-y"
+vmWindowedW = property "config.windowed-w"
+vmWindowedH = property "config.windowed-h"
+vmPrimaryDomainColor = property "config.domain-color"
+vmSecondaryDomainColor = property "config.secondary-domain-color"
 vmStubdomMemory = property "config.stubdom-memory"
 vmStubdomCmdline = property "config.stubdom-cmdline"
 vmBios = property "config.bios"

--- a/xenmgr/Vm/Config.hs
+++ b/xenmgr/Vm/Config.hs
@@ -884,7 +884,7 @@ miscSpecs cfg = do
              d       -> return ["vga='stdvga'", "dm_display='" ++ d ++ "'"]
 
       vkb = readConfigPropertyDef uuid vmVkbd False >>=
-                \ v -> if v then return ["vkb=['backend-type=linux']"]
+                \ v -> if v then return ["vkb=['backend-type=linux,feature-abs-pointer=1,height=32768,width=32768']"]
                             else return []
 
       -- Other config keys taken directly from .config subtree which we delegate directly

--- a/xenmgr/Vm/Pci.hs
+++ b/xenmgr/Vm/Pci.hs
@@ -48,7 +48,6 @@ module Vm.Pci (
            , pciGetMMIOResources
            , pciGetMemHole
            , pciGetMemHoleBase
-           , querySurfmanVgpuMode
            ) where
 
 import Data.Char
@@ -87,7 +86,6 @@ import Tools.Misc
 
 import XenMgr.Rpc
 import XenMgr.Db
-import Rpc.Autogen.SurfmanClient
 
 import Vm.PciDatabase
 import Vm.Types
@@ -314,28 +312,6 @@ pciDriverPath addr = pciSysfsDevPath addr </> "driver"
 pciGetInfo :: PciDev -> IO (Maybe PciInfo)
 pciGetInfo dev = listToMaybe . map snd . filter byDev . unPciCache <$> readPciCache
   where byDev (dev',_) = dev' == dev
-
--- query the surface manager for list of pt devices in passthrough mode / vgpu mode parameters
-querySurfmanVgpuMode :: Rpc (Maybe VgpuMode)
-querySurfmanVgpuMode = do
-    r <- ( Just <$>
-           comCitrixXenclientSurfmanVgpuMode "com.citrix.xenclient.surfman" "/"
-         ) `catchError` (\_ -> return Nothing)
-    case r of
-      Nothing -> return Nothing
-      Just (max_count, dev_name, msi_trans, bdfs) ->
-          let devices = pci_pt max_count bdfs msi_trans (T.pack dev_name) in
-          return . Just $ VgpuMode (fromIntegral max_count) dev_name msi_trans devices
-
-    where
-      -- fill the msi translate flag & dev name
-      pci_pt 0 _    _   _    = []
-      pci_pt _ []   _   _    = []
-      pci_pt _ bdfs msi name = map (fill msi name) . catMaybes . map (parsePciPtDev SourceVendorPlugin) $ bdfs
-
-      fill msi name d =
-          d { pciPtMsiTranslate = msi
-            , pciPtDevice = (pciPtDevice d) { devNameT = name } }
 
 -- | driver bits
 newtype PciDriver = PciDriver { pciDriverName :: String } deriving (Eq, Show)

--- a/xenmgr/Vm/Pci.hs
+++ b/xenmgr/Vm/Pci.hs
@@ -204,6 +204,9 @@ pvmPciPtRules =
 gpuPciPtRule :: PciPtRule
 gpuPciPtRule = PciPtRule (Just 0x300) Nothing Nothing True
 
+gpuPciPtRuleAlt :: PciPtRule
+gpuPciPtRuleAlt = PciPtRule (Just 0x380) Nothing Nothing True
+
 -- Match PCI devices on this machine against passthrough rules, output a result in the form of pci addresses
 matchingPciAddresses :: PciPtRule -> IO [(PciAddr, PciPtGuestSlot)]
 matchingPciAddresses (PciPtRuleBDF addr fslot)
@@ -286,7 +289,7 @@ pciGetMatchingDevices src rules = unions <$> mapM from_rule rules
       unions = S.toList . S.unions . map S.fromList
 
 pciGetGpus :: IO [PciDev]
-pciGetGpus = mapM (pciGetDevice . fst) =<< matchingPciAddresses gpuPciPtRule
+pciGetGpus = mapM (pciGetDevice . fst) =<< matchingPciAddressesMany [gpuPciPtRule, gpuPciPtRuleAlt]
 
 pciGetSecondaryGpus :: IO [PciDev]
 pciGetSecondaryGpus = filterM pciGpuIsSecondary =<< pciGetGpus

--- a/xenmgr/Vm/Queries.hs
+++ b/xenmgr/Vm/Queries.hs
@@ -23,14 +23,12 @@ module Vm.Queries
                , getDomainUuid
                , getStubDomainID
                , whenDomainID, whenDomainID_
-               , getFocusVm
                , getVms
                , getVmsBy
                , getVmsByType
                , getVmByDomid
                , getVmShutdownOrder
                , getGuestVms
-               , getRunningHDX
                , getGraphicsFallbackVm
                , getDefaultNetworkBackendVm
                , getConfigCorruptionInfo
@@ -57,7 +55,6 @@ module Vm.Queries
                , getCryptoKeyLookupPaths
                , getPciPtRules
                , getPciPtDevices
-               , getVisibleVms
                , whenVmRunning
                , isRunning
                , isLoginRequired
@@ -71,7 +68,7 @@ module Vm.Queries
                , getSeamlessVms
                  -- property accessors
                , getVmVirtType
-               , getVmType, getVmGraphics, getMaxVgpus
+               , getVmType
                , getVmWiredNetwork, getVmWirelessNetwork, getVmGpu, getVmCd, getVmMac, getVmAmtPt, getVmPorticaEnabled, getVmPorticaInstalled
                , getVmSeamlessTraffic, getVmAutostartPending, getVmHibernated, getVmMemoryStaticMax
                , getVmMemoryMin
@@ -182,16 +179,12 @@ allVms :: MonadRpc e m => m [Uuid]
 allVms = map fromString <$> dbList "/vm"
 
 -- VMS with corrupt configs
+-- TODO: need implementation
 getConfigCorruptionInfo :: Rpc [(Uuid,String)]
 getConfigCorruptionInfo = do
     vms  <- allVms
     cfgs <- mapM (\uuid -> getVmConfig uuid False) vms
-    return $ foldl' f [] cfgs
-  where
-    f acc cfg =
-        case diagnose cfg of
-          []   ->  acc
-          p:ps -> (vmcfgUuid cfg,p) : acc
+    return []
 
 -- VMS with correct configs
 -- UPDATE: removed the correctness check, it was slowing the RPC extremely and does not protect
@@ -220,11 +213,6 @@ plugBackendDomains cfg =
             domid <- getDomainID uuid
             return $ nic { nicdefBackendDomid = domid }
 
-getMaxVgpus :: Rpc Int
-getMaxVgpus = vgpu <$> querySurfmanVgpuMode
-    where vgpu Nothing  = 0
-          vgpu (Just v) = vgpuMaxVGpus v
-
 isHVM :: VirtType -> Bool
 isHVM vt = vt == HVM
 
@@ -245,8 +233,6 @@ getVmConfig uuid resolve_backend_uuids =
        qemu <- future $ getVmQemuDmPath uuid
        qemu_timeout <- future $ getVmQemuDmTimeout uuid
        excl_cd <- future $ policyQueryCdExclusive
-       vgpu <- future $ ifM (isHVM <$> getVmVirtType uuid) querySurfmanVgpuMode (return Nothing)
-       gfx <- future $ getVmGraphics uuid
        oem_acpi <- future $ getVmOemAcpiFeatures uuid
        pv_addons <- future $ getVmPvAddons uuid
        autostart <- future $ getVmStartOnBoot uuid
@@ -286,11 +272,9 @@ getVmConfig uuid resolve_backend_uuids =
                      <*> nets
                      <*> key_dirs
                      <*> pv_addons
-                     <*> gfx
                      <*> rdd
                      <*> rds
                      <*> oem_acpi
-                     <*> vgpu
                      <*> pcis
                      <*> excl_cd
                      <*> autostart
@@ -421,18 +405,15 @@ getVmTrackDependencies uuid = readConfigPropertyDef uuid vmTrackDependencies Fal
 
 getVmSeamlessMouseX :: Uuid -> (String -> Rpc [HostGpu]) -> Rpc (Maybe Uuid)
 getVmSeamlessMouseX uuid gpusNextTo =
-    do gpu <- gpu_id <$> getVmGpu uuid
+    do gpu <- getVmGpu uuid
        adjacent_gpus <- map gpuId <$> ( gpusNextTo gpu `catchError` (\ex -> return []))
        return . first
          =<< filterM isRunning
          =<< return . concat
          =<< mapM with_gpu adjacent_gpus
     where
-      gpu_id "" = "hdx"
-      gpu_id  x = x
       first [] = Nothing
       first (uuid:_) = Just $ uuid
-      with_gpu "hdx" = getVisibleVms
       with_gpu gpu   = getVmsBy (\vm -> (== gpu) <$> getVmGpu vm)
 
 getVmSeamlessMouseLeft :: Uuid -> Rpc Int
@@ -507,23 +488,6 @@ groupVmsBy get_property uuids =
            rs = groupBy (\a b -> snd a == snd b) vs
        return . map (map fst) $ rs
 
--- get the vm uuid which is supposed to have focus
-getFocusVm :: Rpc (Maybe Uuid)
-getFocusVm =
-    do maybe_uuid <- liftIO $ xsRead "/local/domain/0/switcher/focus-uuid"
-       return . fmap fromString $ maybe_uuid
-
--- get the visible domains (surfman query)
--- NOTE: this doesn't include vms which surfman does not know about, i.e. something which
--- uses passthrough GPU directly
-getVisibleDomids :: Rpc [DomainID]
-getVisibleDomids
-  = map fromIntegral <$>
-     comCitrixXenclientSurfmanGetVisible "com.citrix.xenclient.surfman" "/" `catchError` \_ -> return []
-
-getVisibleVms :: Rpc [Uuid]
-getVisibleVms = catMaybes <$> (mapM getDomainUuid =<< getVisibleDomids)
-
 -- shutdown by descending priority, in parallel if priority equal
 getVmShutdownOrder :: Rpc [[Uuid]]
 getVmShutdownOrder =
@@ -540,12 +504,6 @@ getGuestVms =
       match_guest_type Svm = True
       match_guest_type _   = False
       is_guest uuid = match_guest_type <$> getVmType uuid
-
-getRunningHDX :: Rpc [Uuid]
-getRunningHDX = do
-    filterM isRunning =<< getVmsBy isHDX
-    where
-      isHDX uuid = getVmGraphics uuid >>= return . (== HDX)
 
 getGraphicsFallbackVm :: Rpc (Maybe Uuid)
 getGraphicsFallbackVm = do
@@ -708,22 +666,15 @@ getPciPtRulesList uuid =
 -- Get passthrough devices for a VM
 getPciPtDevices :: Uuid -> Rpc [PciPtDev]
 getPciPtDevices uuid =
-    do gfx <- getVmGraphics uuid
-       amt <- amtPtActive uuid
+    do amt <- amtPtActive uuid
        -- We've got PCI rules for a specifc VM
        vm_rules <- getPciPtRulesList uuid
-       -- We've got PCI rules for HDX
-       hdx_devs <- case gfx of
-                     HDX -> querySurfmanVgpuMode >>= return . vgpu_devs
-                     _   -> return []
        -- And then there are AMT passthrough rules
        let amt_rules = case amt of True -> amtPciPtRules
                                    _    -> []
        -- And optional secondary gpu devs based on GPU property
-       -- ('hdx' indicates surfman devices and should be ignored here)
        gpu_addr_str <- readConfigPropertyDef uuid vmGpu ""
-       let gpu_addr = case gpu_addr_str of "hdx" -> Nothing
-                                           _     -> pciFromStr gpu_addr_str
+       let gpu_addr = pciFromStr gpu_addr_str
        gpu_dev  <- liftIO $ case gpu_addr of
                      Nothing   -> return []
                      Just addr -> do dev <- pciGetDevice addr
@@ -732,10 +683,7 @@ getPciPtDevices uuid =
        let rules = amt_rules ++ vm_rules
 
        devs_from_rules <- liftIO $ pciGetMatchingDevices SourceConfig rules
-       return $ hdx_devs ++ gpu_dev ++ devs_from_rules
-    where
-      vgpu_devs Nothing = []
-      vgpu_devs (Just mode) = vgpuPciPtDevices mode
+       return $ gpu_dev ++ devs_from_rules
 
 getVmFirewallRules :: Uuid -> Rpc [Firewall.Rule]
 getVmFirewallRules uuid = readConfigPropertyDef uuid vmFirewallRules []
@@ -789,21 +737,7 @@ getVmWirelessNetwork uuid
       first (n:_) = Just $ nicdefNetwork n
 
 getVmGpu :: MonadRpc e m => Uuid -> m String
-getVmGpu uuid
-  = ifM (getVmNativeExperience uuid)
-      hdxIfTools {- else -} current
-  where
-    current = readConfigPropertyDef uuid vmGpu ""
-    hdxIfTools
-      = ifM (getVmPvAddons uuid)
-          (return "hdx") {- else -} current
-
-getVmGraphics :: MonadRpc e m => Uuid -> m VmGraphics
-getVmGraphics uuid =
-    do gpu <- getVmGpu uuid
-       return $ case gpu of
-                  "hdx" -> HDX
-                  _ -> VGAEmu
+getVmGpu uuid = readConfigPropertyDef uuid vmGpu ""
 
 -- cd inserted in virtual drive
 getVmCd :: Uuid -> Rpc String
@@ -1016,10 +950,7 @@ getVmVsnd uuid = readConfigPropertyDef uuid vmVsnd False
 getVmShutdownPriority uuid =
     readConfigProperty uuid vmShutdownPriority >>= test where
         test (Just pri) = return pri
-        -- default shutdown priority of pvm is lower so it gets shutdown later on
-        test Nothing = getVmGraphics uuid >>= \t -> return $ case t of
-                                                           HDX ->  (-10)
-                                                           _   -> (0 :: Int)
+        test Nothing = return (0 :: Int)
 
 getVmExtraXenvm uuid = concat . intersperse ";" <$> readConfigPropertyDef uuid vmExtraXenvm []
 getVmExtraHvm   uuid = concat . intersperse ";" <$> readConfigPropertyDef uuid vmExtraHvms []

--- a/xenmgr/Vm/Queries.hs
+++ b/xenmgr/Vm/Queries.hs
@@ -173,7 +173,6 @@ import XenMgr.Errors
 import XenMgr.Host
 import XenMgr.Connect.Xl (isRunning)
 import qualified XenMgr.Connect.Xl as Xl
-import Rpc.Autogen.SurfmanClient
 
 import Data.Bits
 import System.IO.Unsafe

--- a/xenmgr/Vm/Queries.hs
+++ b/xenmgr/Vm/Queries.hs
@@ -124,6 +124,22 @@ module Vm.Queries
                , getVmSerial
                , getVmBios
                , getVmHdType
+               , getVmDisplayHandlerStrict
+               , getVmLongForm
+               , getVmShortForm
+               , getVmTextColor
+               , getVmDomainColor
+               , getVmBorderWidth
+               , getVmBorderHeight
+               , getVmMosaicVmEnabled
+               , getVmVglassEnabled
+               , getVmMosaicMode
+               , getVmWindowedX
+               , getVmWindowedY
+               , getVmWindowedW
+               , getVmWindowedH
+               , getVmPrimaryDomainColor
+               , getVmSecondaryDomainColor
                ) where
 
 import Data.String
@@ -256,6 +272,13 @@ getVmConfig uuid resolve_backend_uuids =
        rdd <- future $ getVmRestrictDisplayDepth uuid
        rds <- future $ getVmRestrictDisplayRes uuid
        preserve_on_reboot <- future $ getVmPreserveOnReboot uuid
+       display_handler_strict <- future $ getVmDisplayHandlerStrict uuid
+       long_form <- future $ getVmLongForm uuid
+       short_form <- future $ getVmShortForm uuid
+       text_color <- future $ getVmTextColor uuid
+       domain_color <- future $ getVmDomainColor uuid
+       border_width <- future $ getVmBorderWidth uuid
+       border_height <- future $ getVmBorderHeight uuid
        cfg <-
            force $ VmConfig
                      <$> pure uuid
@@ -290,6 +313,13 @@ getVmConfig uuid resolve_backend_uuids =
                      <*> memmin
                      <*> memmax
                      <*> preserve_on_reboot
+                     <*> display_handler_strict
+                     <*> long_form
+                     <*> short_form
+                     <*> text_color
+                     <*> domain_color
+                     <*> border_width
+                     <*> border_height
        if resolve_backend_uuids
           then plugBackendDomains cfg
           else return cfg
@@ -463,6 +493,55 @@ getVmCpuidResponses uuid = map CpuidResponse . filter (not . null) . map strip .
 
 getVmXciCpuidSignature :: Uuid -> Rpc Bool
 getVmXciCpuidSignature uuid = readConfigPropertyDef uuid vmXciCpuidSignature False
+
+
+getVmMosaicVmEnabled :: Uuid -> Rpc Bool
+getVmMosaicVmEnabled uuid = readConfigPropertyDef uuid vmMosaicVmEnabled False
+
+getVmVglassEnabled :: Uuid -> Rpc Bool
+getVmVglassEnabled uuid = readConfigPropertyDef uuid vmVglassEnabled False
+
+getVmMosaicMode :: Uuid -> Rpc Int
+getVmMosaicMode uuid = readConfigPropertyDef uuid vmMosaicMode 0
+
+getVmWindowedX :: Uuid -> Rpc Int
+getVmWindowedX uuid = readConfigPropertyDef uuid vmWindowedX 0
+
+getVmWindowedY :: Uuid -> Rpc Int
+getVmWindowedY uuid = readConfigPropertyDef uuid vmWindowedY 0
+
+getVmWindowedW :: Uuid -> Rpc Int
+getVmWindowedW uuid = readConfigPropertyDef uuid vmWindowedW 0
+
+getVmWindowedH :: Uuid -> Rpc Int
+getVmWindowedH uuid = readConfigPropertyDef uuid vmWindowedH 0
+
+getVmPrimaryDomainColor :: Uuid -> Rpc String
+getVmPrimaryDomainColor uuid = readConfigPropertyDef uuid vmPrimaryDomainColor ""
+
+getVmSecondaryDomainColor :: Uuid -> Rpc String
+getVmSecondaryDomainColor uuid = readConfigPropertyDef uuid vmSecondaryDomainColor ""
+
+getVmDisplayHandlerStrict :: Uuid -> Rpc Bool
+getVmDisplayHandlerStrict uuid = readConfigPropertyDef uuid vmDisplayHandlerStrict False
+
+getVmLongForm :: Uuid -> Rpc String
+getVmLongForm uuid = readConfigPropertyDef uuid vmLongForm ""
+
+getVmShortForm :: Uuid -> Rpc String
+getVmShortForm uuid = readConfigPropertyDef uuid vmShortForm ""
+
+getVmTextColor :: Uuid -> Rpc String
+getVmTextColor uuid = readConfigPropertyDef uuid vmTextColor ""
+
+getVmDomainColor :: Uuid -> Rpc String
+getVmDomainColor uuid = readConfigPropertyDef uuid vmDomainColor ""
+
+getVmBorderWidth :: Uuid -> Rpc Int
+getVmBorderWidth uuid = readConfigPropertyDef uuid vmBorderWidth 0
+
+getVmBorderHeight :: Uuid -> Rpc Int
+getVmBorderHeight uuid = readConfigPropertyDef uuid vmBorderHeight 0
 
 getVmsByType :: VmType -> Rpc [Uuid]
 getVmsByType t =

--- a/xenmgr/Vm/Queries.hs
+++ b/xenmgr/Vm/Queries.hs
@@ -112,7 +112,6 @@ module Vm.Queries
                , getVmReady
                , getVmProvidesDefaultNetworkBackend
                , getVmVkbd
-               , getVmVfb
                , getVmArgo
                , getVmRestrictDisplayDepth
                , getVmRestrictDisplayRes
@@ -1051,7 +1050,6 @@ getVmOvfTransportIso uuid = readConfigPropertyDef uuid vmOvfTransportIso False
 getVmDownloadProgress uuid = fromMaybe (0::Int) <$> dbRead ("/vm/"++show uuid++"/download-progress")
 getVmReady uuid = readConfigPropertyDef uuid vmReady True
 getVmVkbd uuid = readConfigPropertyDef uuid vmVkbd False
-getVmVfb uuid = readConfigPropertyDef uuid vmVfb False
 getVmArgo uuid = readConfigPropertyDef uuid vmArgo False
 getVmRestrictDisplayDepth uuid = readConfigPropertyDef uuid vmRestrictDisplayDepth False
 getVmRestrictDisplayRes uuid = readConfigPropertyDef uuid vmRestrictDisplayRes False

--- a/xenmgr/Vm/Queries.hs-boot
+++ b/xenmgr/Vm/Queries.hs-boot
@@ -1,0 +1,11 @@
+module Vm.Queries
+   (getVmGpu,
+    getVms
+   ) where
+
+import Vm.Uuid
+import XenMgr.Rpc
+
+getVmGpu :: MonadRpc e m => Uuid -> m String
+
+getVms :: (MonadRpc e m) => m [Uuid]

--- a/xenmgr/Vm/React.hs
+++ b/xenmgr/Vm/React.hs
@@ -272,11 +272,6 @@ whenRunning xm = do
     usb <- uuidRpc getVmUsbEnabled
     when usb $ whenDomainID_ uuid $ \domid -> usbUp (fromIntegral domid)
 
-cleanupVkbd :: Uuid -> DomainID -> Rpc ()
-cleanupVkbd uuid domid = do
-    rpcCallOnce (Xl.xlInputDbus uuid "detach_vkbd" [toVariant $ (read (show domid) :: Int32) ])
-    return ()
-
 maybeCleanupSnapshots :: Vm ()
 maybeCleanupSnapshots = do
     uuid <- vmUuid
@@ -307,8 +302,6 @@ whenShutdown xm reason = do
         usbDown domid
         removeAlsa domid
         cleanupArgoDevice domid
-        vkb_enabled <- getVmVkbd uuid
-        when vkb_enabled $ liftRpc $ cleanupVkbd uuid domid
       _ -> return ()
     liftIO $ removeVmEnvIso uuid
     uuidRpc $ manageFrontVifs False

--- a/xenmgr/Vm/Types.hs
+++ b/xenmgr/Vm/Types.hs
@@ -22,8 +22,6 @@ module Vm.Types (
                , VmState (..)
                , CpuidResponse (..)
                , PorticaStatus (..)
-               , VmGraphics(..)
-               , VgpuMode(..)
                , VmConfig(..)
                , SupportedOS(..)
                , XcVersion(..)
@@ -80,15 +78,6 @@ data PorticaStatus = PorticaStatus {
     , porticaEnabled :: Bool
     } deriving (Eq, Show)
 
-data VgpuMode = VgpuMode {
-      vgpuMaxVGpus :: Int
-    , vgpuName :: String
-    , vgpuMsiTranslate :: Bool
-    , vgpuPciPtDevices :: [PciPtDev]
-    } deriving (Eq, Show)
-
-data VmGraphics = HDX | VGAEmu deriving (Eq,Show)
-
 data XcVersion = XcVersion String deriving (Eq,Ord)
 
 data S3Mode = S3Pv | S3Ignore | S3Restart | S3Snapshot deriving (Eq,Show)
@@ -112,11 +101,9 @@ data VmConfig = VmConfig {
     , vmcfgNetworks :: [NetworkInfo]
     , vmcfgCryptoKeyDirs :: FilePath
     , vmcfgPvAddons :: Bool
-    , vmcfgGraphics :: VmGraphics
     , vmcfgRestrictDisplayDepth :: Bool
     , vmcfgRestrictDisplayRes :: Bool
     , vmcfgOemAcpiFeatures :: Bool
-    , vmcfgVgpuMode :: Maybe VgpuMode
     , vmcfgPciPtDevices :: [PciPtDev]
     , vmcfgCdExclusive :: Bool
     , vmcfgAutostart :: Bool

--- a/xenmgr/Vm/Types.hs
+++ b/xenmgr/Vm/Types.hs
@@ -119,6 +119,13 @@ data VmConfig = VmConfig {
     , vmcfgMemoryMinMib :: Int
     , vmcfgMemoryStaticMaxMib :: Int
     , vmcfgPreserveOnReboot :: Bool
+    , vmcfgDisplayHandlerStrict :: Bool
+    , vmcfgLongForm :: String
+    , vmcfgShortForm :: String
+    , vmcfgTextColor :: String
+    , vmcfgDomainColor :: String
+    , vmcfgBorderWidth :: Int
+    , vmcfgBorderHeight :: Int
     }
 
 data SupportedOS = Linux | Windows | Windows8 | UnknownOS deriving (Eq,Ord)

--- a/xenmgr/XenMgr/Config.hs
+++ b/xenmgr/XenMgr/Config.hs
@@ -58,7 +58,6 @@ module XenMgr.Config
                  , appGetSwitcherKeyboardFollowsMouse, appSetSwitcherKeyboardFollowsMouse
                  , appGetSwitcherResistance, appSetSwitcherResistance
                  , appGetSwitcherStatusReportEnabled, appSetSwitcherStatusReportEnabled
-                 , appGetDrmGraphics, appSetDrmGraphics
                  , appGetSupportedLanguages
                  , appGetLanguage, appSetLanguage
                  , BuildInfo(..)
@@ -372,20 +371,3 @@ dictFile = catMaybes . map (safeHead2 . split '=') . lines
 
 dictFileStr :: [(String,String)] -> String
 dictFileStr = unlines . map mkline where mkline (k,v) = k ++ "=" ++ v
-
-drmScript :: [String] -> IO String
-drmScript opts = readProcessOrDie "/usr/share/xenclient/drm_graphics_option.sh" opts ""
-
-appGetDrmGraphics :: Rpc Bool
-appGetDrmGraphics = liftIO $ do
-  v <- E.try (parse . chomp <$> drmScript ["-g"])
-  case v of
-    Right v' -> return v'
-    Left (e :: E.SomeException) -> return False
-  where
-    parse "true" = True
-    parse _ = False
-
-appSetDrmGraphics :: Bool -> Rpc ()
-appSetDrmGraphics v = liftIO $
-  void $ drmScript ["-u", "-s", if v then "true" else "false"]

--- a/xenmgr/XenMgr/Connect/Xl.hs
+++ b/xenmgr/XenMgr/Connect/Xl.hs
@@ -43,8 +43,6 @@ module XenMgr.Connect.Xl
     --dbus stuff
     , onNotify
     , onNotifyRemove
-    , xlSurfmanDbus
-    , xlInputDbus
     , setNicBackendDom
     , removeNic
     , addNic
@@ -435,24 +433,6 @@ onNotifyRemove uuid msgname action =
                case splits of
                  (msg:args) | msg == msgname    -> action args
                  _                              -> return ()
-
---Construct an RPC message for surfman given an argument list and
---command to run.
-xlSurfmanDbus uuid memb args =
-  RpcCall service object interface (fromString memb) args
-  where
-    service = fromString $ "com.citrix.xenclient.surfman"
-    interface = fromString $ "com.citrix.xenclient.surfman"
-    object = fromString $ "/"
-
---Construct an RPC for inputserver given an argument list and
---command to run
-xlInputDbus uuid memb args =
-  RpcCall service object interface (fromString memb) args
-  where
-    service = fromString $ "com.citrix.xenclient.input"
-    interface = fromString $ "com.citrix.xenclient.input"
-    object = fromString $ "/"
 
 --Path to the xl config file generated on domain creation
 configPath uuid = "/tmp/xenmgr-xl-" ++ show uuid

--- a/xenmgr/XenMgr/Errors.hs
+++ b/xenmgr/XenMgr/Errors.hs
@@ -19,8 +19,7 @@
 {-# LANGUAGE FlexibleContexts, DeriveDataTypeable #-}
 
 module XenMgr.Errors (
-                   failSimultaneousAutostartAndHdx
-                 , failHibernateFailed
+                   failHibernateFailed
                  , failCannotEditPropertiesDueToPolicy
                  , failDuplicateDevice
                  , failNoSuchDevice
@@ -29,15 +28,11 @@ module XenMgr.Errors (
                  , failNoSuchDisk
                  , failIncorrectDiskType
                  , failIncorrectDeviceType
-                 , failCannotTurnHdxWhenVmRunning
-                 , failCannotTurnHdxWithoutPvAddons
-                 , failCannotStartHdxWithoutVtD
                  , failActionRequiresPvAddons
                  , failPropertyIsReadonly
                  , failPropertyIsWriteonly
                  , failNotGatheringDiagnostics
                  , failDiskSha1SumDoesNotMatch
-                 , failCannotStartBecauseHdxRunning
                  , failCannotStartBecauseAmtPtRunning
                  , failCannotStartBecauseOemFeaturesRunning
                  , failActionSuppressedByPolicy
@@ -101,9 +96,6 @@ failNotEnoughMemory :: (MonadError XmError m) => m a
 failNotEnoughMemory = throwError $ XError 101 "Not enough memory!"
 
 -- List of literate errors thrown to upper layers (UI)
-failSimultaneousAutostartAndHdx :: (MonadError XmError m) => m a
-failSimultaneousAutostartAndHdx = throwError $ XError 200 "HDX and Autostart cannot be simultaneously activated on more than one VM."
-
 failHibernateFailed :: (MonadError XmError m) => m a
 failHibernateFailed = throwError $ XError 201 "Failed to hibernate VM"
 
@@ -128,15 +120,6 @@ failIncorrectDiskType = throwError $ XError 207 "Incorrect disk type"
 failIncorrectDeviceType :: (MonadError XmError m) => m a
 failIncorrectDeviceType = throwError $ XError 208 "Incorrect device type"
 
-failCannotTurnHdxWhenVmRunning :: (MonadError XmError m) => m a
-failCannotTurnHdxWhenVmRunning = throwError $ XError 209 "Cannot turn HDX on/off while the VM is running"
-
-failCannotTurnHdxWithoutPvAddons :: (MonadError XmError m) => m a
-failCannotTurnHdxWithoutPvAddons = throwError $ XError 210 "Cannot turn HDX on until XenClient PV addons are installed inside the guest"
-
-failCannotStartHdxWithoutVtD :: (MonadError XmError m) => m a
-failCannotStartHdxWithoutVtD = throwError $ XError 211 "Cannot start VM with HDX because VT-d is turned off."
-
 failDuplicateDevice :: (MonadError XmError m) => m a
 failDuplicateDevice = throwError $ XError 212 "Failed to add a disk, device ID is duplicated"
 
@@ -154,9 +137,6 @@ failNotGatheringDiagnostics = throwError $ XError 216 "Currently not gathering d
 
 failDiskSha1SumDoesNotMatch :: (MonadError XmError m) => m a
 failDiskSha1SumDoesNotMatch = throwError $ XError 217 "Disk SHA1 sum does not match the expected one!"
-
-failCannotStartBecauseHdxRunning :: (MonadError XmError m) => m a
-failCannotStartBecauseHdxRunning = throwError $ XError 218 "Cannot start VM - too many vms with HDX are already running"
 
 failCannotStartBecauseAmtPtRunning :: (MonadError XmError m) => m a
 failCannotStartBecauseAmtPtRunning = throwError $ XError 219 "Cannot start VM - another VM with AMT passthrough is already running"

--- a/xenmgr/XenMgr/Expose/HostObject.hs
+++ b/xenmgr/XenMgr/Expose/HostObject.hs
@@ -155,6 +155,9 @@ implementation xm host_info_cache = do
   , comCitrixXenclientXenmgrInstallerGetEula              = getEULA
   , comCitrixXenclientXenmgrInstallerGetInstallstate      = _GetInstallstate
   , comCitrixXenclientXenmgrInstallerProgressInstallstate = _ProgressInstallstate
+  , comCitrixXenclientXenmgrHostGetDisplayhandlerGpu = getDisplayHandlerGpu
+  , comCitrixXenclientXenmgrHostSetDisplayhandlerGpu = \gpu -> setDisplayHandlerGpu gpu
+  , comCitrixXenclientXenmgrHostListGpusForDisplayhandler = _ListGpusForDisplayhandler
   }
 
   where
@@ -260,10 +263,22 @@ _ListPciDevices =
                             ]
 
 _ListGpuDevices :: Rpc [Map String String]
-_ListGpuDevices = map dict_entry <$> getGpuPlacements where
-    dict_entry (d,p) = M.fromList $ [ ("addr", gpuId d)
-                                    , ("name", gpuName d)
-                                    , ("placement", show p) ]
+_ListGpuDevices =
+    map dict_entry <$> getGpuPlacements
+  where
+    dict_entry (d,p) =
+      M.fromList $ [ ("addr", gpuId d)
+                   , ("name", gpuName d)
+                   , ("placement", show p) ]
+
+_ListGpusForDisplayhandler :: Rpc [Map String String]
+_ListGpusForDisplayhandler =
+    map dict_entry <$> getGpusForDisplayhandler
+  where
+    dict_entry (d,c) =
+      M.fromList $ [ ("addr", gpuId d)
+                   , ("name", gpuName d)
+                   , ("drmcard", show c) ]
 
 _GetGpuPlacement :: String -> Rpc Int32
 _GetGpuPlacement id = fromIntegral <$> getGpuPlacement id

--- a/xenmgr/XenMgr/Expose/VmObject.hs
+++ b/xenmgr/XenMgr/Expose/VmObject.hs
@@ -652,11 +652,6 @@ implementationFor xm uuid = self where
   , comCitrixXenclientXenmgrVmSetVkbd = restrict' $ setVmVkbd uuid
   , comCitrixXenclientXenmgrVmUnrestrictedSetVkbd = setVmVkbd uuid
 
-  , comCitrixXenclientXenmgrVmGetVfb = getVmVfb uuid
-  , comCitrixXenclientXenmgrVmUnrestrictedGetVfb = getVmVfb uuid
-  , comCitrixXenclientXenmgrVmSetVfb = restrict' $ setVmVfb uuid
-  , comCitrixXenclientXenmgrVmUnrestrictedSetVfb = setVmVfb uuid
-
   , comCitrixXenclientXenmgrVmGetArgo = getVmArgo uuid
   , comCitrixXenclientXenmgrVmUnrestrictedGetArgo = getVmArgo uuid
   , comCitrixXenclientXenmgrVmSetArgo = restrict' $ setVmArgo uuid

--- a/xenmgr/XenMgr/Expose/VmObject.hs
+++ b/xenmgr/XenMgr/Expose/VmObject.hs
@@ -329,6 +329,54 @@ implementationFor xm uuid = self where
   , comCitrixXenclientXenmgrVmUnrestrictedGetDomstoreReadAccess = getDomstoreReadAccess uuid
   , comCitrixXenclientXenmgrVmUnrestrictedSetDomstoreWriteAccess = setDomstoreWriteAccess uuid
   , comCitrixXenclientXenmgrVmUnrestrictedGetDomstoreWriteAccess = getDomstoreWriteAccess uuid
+  , comCitrixXenclientXenmgrVmUnrestrictedGetStubDomid = fromIntegral . fromMaybe (-1) <$> getStubDomainID uuid
+  , comCitrixXenclientXenmgrVmUnrestrictedGetImagePathVg = getVmImagePath uuid
+  , comCitrixXenclientXenmgrVmUnrestrictedSetImagePathVg = \v -> setVmImagePath uuid v
+
+  , comCitrixXenclientXenmgrVmUnrestrictedGetDisplayHandlerStrict = getVmDisplayHandlerStrict uuid
+  , comCitrixXenclientXenmgrVmUnrestrictedSetDisplayHandlerStrict = \v -> setVmDisplayHandlerStrict uuid v
+
+  , comCitrixXenclientXenmgrVmUnrestrictedGetLongFormVg = getVmLongForm uuid
+  , comCitrixXenclientXenmgrVmUnrestrictedSetLongFormVg = \v -> setVmLongForm uuid v
+
+  , comCitrixXenclientXenmgrVmUnrestrictedGetShortFormVg = getVmShortForm uuid
+  , comCitrixXenclientXenmgrVmUnrestrictedSetShortFormVg = \v -> setVmShortForm uuid v
+
+  , comCitrixXenclientXenmgrVmUnrestrictedGetTextColorVg = getVmTextColor uuid
+  , comCitrixXenclientXenmgrVmUnrestrictedSetTextColorVg = \v -> setVmTextColor uuid v
+
+  , comCitrixXenclientXenmgrVmUnrestrictedGetBorderWidthVg = fromIntegral <$> getVmBorderWidth uuid
+  , comCitrixXenclientXenmgrVmUnrestrictedSetBorderWidthVg = \v -> setVmBorderWidth uuid (fromIntegral v)
+
+  , comCitrixXenclientXenmgrVmUnrestrictedGetBorderHeightVg = fromIntegral <$> getVmBorderHeight uuid
+  , comCitrixXenclientXenmgrVmUnrestrictedSetBorderHeightVg = \v -> setVmBorderHeight uuid (fromIntegral v)
+
+  , comCitrixXenclientXenmgrVmUnrestrictedGetVglassEnabled = getVmVglassEnabled uuid
+  , comCitrixXenclientXenmgrVmUnrestrictedSetVglassEnabled = \v -> setVmVglassEnabled uuid v
+
+  , comCitrixXenclientXenmgrVmUnrestrictedGetMosaicMode =  fromIntegral <$> getVmMosaicMode uuid
+  , comCitrixXenclientXenmgrVmUnrestrictedSetMosaicMode = \v -> setVmMosaicMode uuid (fromIntegral v)
+
+  , comCitrixXenclientXenmgrVmUnrestrictedGetWindowedX =  fromIntegral <$> getVmWindowedX uuid
+  , comCitrixXenclientXenmgrVmUnrestrictedSetWindowedX = \v -> setVmWindowedX uuid (fromIntegral v)
+
+  , comCitrixXenclientXenmgrVmUnrestrictedGetWindowedY =  fromIntegral <$> getVmWindowedY uuid
+  , comCitrixXenclientXenmgrVmUnrestrictedSetWindowedY = \v -> setVmWindowedY uuid (fromIntegral v)
+
+  , comCitrixXenclientXenmgrVmUnrestrictedGetWindowedW =  fromIntegral <$> getVmWindowedW uuid
+  , comCitrixXenclientXenmgrVmUnrestrictedSetWindowedW = \v -> setVmWindowedW uuid (fromIntegral v)
+
+  , comCitrixXenclientXenmgrVmUnrestrictedGetWindowedH =  fromIntegral <$> getVmWindowedH uuid
+  , comCitrixXenclientXenmgrVmUnrestrictedSetWindowedH = \v -> setVmWindowedH uuid (fromIntegral v)
+
+  , comCitrixXenclientXenmgrVmUnrestrictedGetPrimaryDomainColor = getVmPrimaryDomainColor uuid
+  , comCitrixXenclientXenmgrVmUnrestrictedSetPrimaryDomainColor = \v -> setVmPrimaryDomainColor uuid v
+
+  , comCitrixXenclientXenmgrVmUnrestrictedGetSecondaryDomainColor = getVmSecondaryDomainColor uuid
+  , comCitrixXenclientXenmgrVmUnrestrictedSetSecondaryDomainColor = \v -> setVmSecondaryDomainColor uuid v
+
+  , comCitrixXenclientXenmgrVmUnrestrictedGetMosaicVmEnabled = getVmMosaicVmEnabled uuid
+  , comCitrixXenclientXenmgrVmUnrestrictedSetMosaicVmEnabled = \v -> setVmMosaicVmEnabled uuid v
 
     -- bucketload of properties -- restricted version
     -------------------------------------------------
@@ -668,6 +716,54 @@ implementationFor xm uuid = self where
   , comCitrixXenclientXenmgrVmUnrestrictedGetHdtype = getVmHdType uuid
   , comCitrixXenclientXenmgrVmSetHdtype = \v -> restrict >> setVmHdType uuid v
   , comCitrixXenclientXenmgrVmUnrestrictedSetHdtype = \v -> setVmHdType uuid v
+
+  , comCitrixXenclientXenmgrVmGetDisplayHandlerStrict = getVmDisplayHandlerStrict uuid
+  , comCitrixXenclientXenmgrVmSetDisplayHandlerStrict = \v -> restrict >> setVmDisplayHandlerStrict uuid v
+
+  , comCitrixXenclientXenmgrVmGetImagePathVg = getVmImagePath uuid
+  , comCitrixXenclientXenmgrVmSetImagePathVg = \v -> restrict >> setVmImagePath uuid v
+
+  , comCitrixXenclientXenmgrVmGetLongFormVg = getVmLongForm uuid
+  , comCitrixXenclientXenmgrVmSetLongFormVg = \v -> restrict >> setVmLongForm uuid v
+
+  , comCitrixXenclientXenmgrVmGetShortFormVg = getVmShortForm uuid
+  , comCitrixXenclientXenmgrVmSetShortFormVg = \v -> restrict >> setVmShortForm uuid v
+
+  , comCitrixXenclientXenmgrVmGetTextColorVg = getVmTextColor uuid
+  , comCitrixXenclientXenmgrVmSetTextColorVg = \v -> restrict >> setVmTextColor uuid v
+
+  , comCitrixXenclientXenmgrVmGetBorderWidthVg = fromIntegral <$> getVmBorderWidth uuid
+  , comCitrixXenclientXenmgrVmSetBorderWidthVg = \v -> restrict >> setVmBorderWidth uuid (fromIntegral v)
+
+  , comCitrixXenclientXenmgrVmGetBorderHeightVg = fromIntegral <$> getVmBorderHeight uuid
+  , comCitrixXenclientXenmgrVmSetBorderHeightVg = \v -> restrict >> setVmBorderHeight uuid (fromIntegral v)
+
+  , comCitrixXenclientXenmgrVmGetVglassEnabled = getVmVglassEnabled uuid
+  , comCitrixXenclientXenmgrVmSetVglassEnabled = \v -> restrict >> setVmVglassEnabled uuid v
+
+  , comCitrixXenclientXenmgrVmGetMosaicVmEnabled = getVmMosaicVmEnabled uuid
+  , comCitrixXenclientXenmgrVmSetMosaicVmEnabled = \v -> restrict >> setVmMosaicVmEnabled uuid v
+
+  , comCitrixXenclientXenmgrVmGetMosaicMode =  fromIntegral <$> getVmMosaicMode uuid
+  , comCitrixXenclientXenmgrVmSetMosaicMode = \v -> restrict >> setVmMosaicMode uuid (fromIntegral v)
+
+  , comCitrixXenclientXenmgrVmGetWindowedX =  fromIntegral <$> getVmWindowedX uuid
+  , comCitrixXenclientXenmgrVmSetWindowedX = \v -> restrict >> setVmWindowedX uuid (fromIntegral v)
+
+  , comCitrixXenclientXenmgrVmGetWindowedY =  fromIntegral <$> getVmWindowedY uuid
+  , comCitrixXenclientXenmgrVmSetWindowedY = \v -> restrict >> setVmWindowedY uuid (fromIntegral v)
+
+  , comCitrixXenclientXenmgrVmGetWindowedW =  fromIntegral <$> getVmWindowedW uuid
+  , comCitrixXenclientXenmgrVmSetWindowedW = \v -> restrict >> setVmWindowedW uuid (fromIntegral v)
+
+  , comCitrixXenclientXenmgrVmGetWindowedH =  fromIntegral <$> getVmWindowedH uuid
+  , comCitrixXenclientXenmgrVmSetWindowedH = \v -> restrict >> setVmWindowedH uuid (fromIntegral v)
+
+  , comCitrixXenclientXenmgrVmGetPrimaryDomainColor = getVmPrimaryDomainColor uuid
+  , comCitrixXenclientXenmgrVmSetPrimaryDomainColor = \v -> restrict >> setVmPrimaryDomainColor uuid v
+
+  , comCitrixXenclientXenmgrVmGetSecondaryDomainColor = getVmSecondaryDomainColor uuid
+  , comCitrixXenclientXenmgrVmSetSecondaryDomainColor = \v -> restrict >> setVmSecondaryDomainColor uuid v
 
   } where
     stom "" = Nothing

--- a/xenmgr/XenMgr/Expose/XenmgrObject.hs
+++ b/xenmgr/XenMgr/Expose/XenmgrObject.hs
@@ -134,9 +134,6 @@ implementation xm testingCtx =
   , comCitrixXenclientXenmgrConfigGetAutolockCdDrives = appGetAutolockCdDrives
   , comCitrixXenclientXenmgrConfigSetAutolockCdDrives = hostChangeAutolockCdDrives
 
-  , comCitrixXenclientXenmgrConfigUiGetDrmGraphics = appGetDrmGraphics
-  , comCitrixXenclientXenmgrConfigUiSetDrmGraphics = appSetDrmGraphics
-
   , comCitrixXenclientXenmgrConfigUiGetSwitcherEnabled = appGetSwitcherEnabled
   , comCitrixXenclientXenmgrConfigUiSetSwitcherEnabled = appSetSwitcherEnabled
   , comCitrixXenclientXenmgrConfigUiGetSwitcherSelfSwitchEnabled = appGetSwitcherSelfSwitchEnabled

--- a/xenmgr/XenMgr/Host.hs
+++ b/xenmgr/XenMgr/Host.hs
@@ -568,8 +568,8 @@ data HostGpu =
      HostGpu { gpuId :: String
              , gpuName :: String } deriving (Eq,Show)
 
-getSurfmanGpu :: Rpc (Maybe HostGpu)
-getSurfmanGpu = do
+getBootVga :: Rpc (Maybe HostGpu)
+getBootVga = do
     devices  <- liftIO pciGetDevices
     devMatch <- filterM boot_vga_filter devices
     case devMatch of
@@ -603,9 +603,9 @@ getHostGpus =
 
 getHostGpus' :: Rpc [HostGpu]
 getHostGpus' = do
-  surfman   <- to_l <$> getSurfmanGpu
+  primary <- to_l <$> getBootVga
   secondary <- secondary_devs =<< appMultiGpuPt
-  return ( surfman ++ map host_gpu secondary )
+  return ( primary ++ map host_gpu secondary )
   where
     to_l Nothing  = []
     to_l (Just x) = [x]

--- a/xenmgr/XenMgr/Notify.hs
+++ b/xenmgr/XenMgr/Notify.hs
@@ -27,6 +27,7 @@ module XenMgr.Notify (
                      , notifyStorageSpaceLow
                      , notifyDiagGatherRequest
                      , updateKeyedNotifyTask
+                     , notifyDisplayHandlerGpuChanged
                      ) where
 import Data.String
 import Data.Int
@@ -49,6 +50,10 @@ notifyHostStateChanged state =
 notifyLicenseChanged :: (MonadRpc e m) => m ()
 notifyLicenseChanged =
   notifyComCitrixXenclientXenmgrHostLicenseChanged (fromString "/host")
+
+notifyDisplayHandlerGpuChanged :: (MonadRpc e m) => m ()
+notifyDisplayHandlerGpuChanged =
+  notifyComCitrixXenclientXenmgrHostDisplayhandlerGpuChanged (fromString "/host")
 
 configChangedTasks :: MVar (Map Uuid ScheduledTask)
 {-# NOINLINE configChangedTasks #-}

--- a/xenmgr/XenMgr/PowerManagement.hs
+++ b/xenmgr/XenMgr/PowerManagement.hs
@@ -72,7 +72,6 @@ import XenMgr.XM
 import Vm.Queries
 import Vm.State
 import XenMgr.Rpc
-import Rpc.Autogen.SurfmanClient
 import qualified XenMgr.Connect.Xl as Xl
 import XenMgr.Connect.InputDaemon
 

--- a/xenmgr/xenmgr.cabal
+++ b/xenmgr/xenmgr.cabal
@@ -27,6 +27,7 @@ Executable xenmgr
     regex-posix,
     hsyslog,
     zlib,
+    split,
     xch-rpc,
     xchutils,
     xchargo,


### PR DESCRIPTION
This changeset has 3 steps:
- Remove Surfman's integration and rules hardwired in the toolstack;
- Add vglass RPC and required logic to enable the vglass graphic stack;
- Enable vglass as the default graphic stack.

vglass support is enabled through the `vglass-enabled` configuration property, which is enabled by default for new guests and UIVM.

NOTE: PV and PVH guests that rely on openxtfb or glassdrm (e.g, UIVM) may experience a 30s boot time delay as xenbus will wait for the PV framebuffer/input devices to be connected to their backends. This is why `xenbus.wait_nonessentials` is provided and introduced by a Linux path in xenclient-oe.

NOTE: At the moment, emulated pointing devices do not work if PV tools are installed in Windows guests, this is why the configuration property `vkbd` is turned on by default to let `glass` handle a PV input instead.