### PR TITLE
RFC: rpc-proxy, xenmgr, updatemgr: Use rpc-autogen bindings module

### DIFF
--- a/rpc-proxy/rpc-proxy.cabal
+++ b/rpc-proxy/rpc-proxy.cabal
@@ -38,7 +38,8 @@ Executable rpc-proxy
     transformers-base,
     xchwebsocket,
     xchxenstore,
-    xchdb
+    xchdb,
+    rpc-autogen
   Main-Is: Main.hs
   if flag(stubdom)
     GHC-Options: -O2 -fwarn-incomplete-patterns -static -optl-static -optl-pthread

--- a/updatemgr/updatemgr.cabal
+++ b/updatemgr/updatemgr.cabal
@@ -35,6 +35,7 @@ Executable updatemgr
     monad-control,
     monad-loops,
     hinotify,
-    HTTP
+    HTTP,
+    rpc-autogen
   Main-Is: Main.hs
   GHC-Options: -O2 -fwarn-incomplete-patterns -dynamic -threaded

--- a/xenmgr/xenmgr.cabal
+++ b/xenmgr/xenmgr.cabal
@@ -33,7 +33,8 @@ Executable xenmgr
     xchargo,
     xchxenstore,
     xchdb,
-    xenmgr-core
+    xenmgr-core,
+    rpc-autogen
 
   Main-Is: Main.hs
   GHC-Options: -O2 -Werror -fwarn-incomplete-patterns -threaded -dynamic


### PR DESCRIPTION
dbus-gen generates a set of bindings for the currently supported API. Use the built module instead of relying on generating the bindings from the IDL in the source tree.