### PR TITLE
templates: Make sync pvh and hap

### DIFF
--- a/templates/default/new-vm-sync
+++ b/templates/default/new-vm-sync
@@ -14,11 +14,11 @@
   },
   "config": {
     "notify": "dbus",
-    "virt-type": "pv",
+    "virt-type": "pvh",
     "pae": "true",
     "acpi": "true",
     "apic": "true",
-    "hap": "false",
+    "hap": "true",
     "nx": "true",
     "argo": "true",
     "memory": "256",


### PR DESCRIPTION
Default syncvm to running as a PVH with HAP, hardware assisted paging,
enabled.  PVH and HAP avoid spectre & meltdown security issues associated
with PV.

Signed-off-by: Jason Andryuk <jandryuk@gmail.com>

Depends on https://github.com/OpenXT/xenclient-oe/pull/1420 and https://github.com/OpenXT/xsm-policy/pull/38