### PR TITLE
[guest-efi] Add secureboot & authenforce guest properties

### DIFF
--- a/xenmgr/Vm/Actions.hs
+++ b/xenmgr/Vm/Actions.hs
@@ -116,6 +116,8 @@ module Vm.Actions
           , setVmNestedHvm
           , setVmSerial
           , setVmBios
+          , setVmSecureboot
+          , setVmAuthenforce
           , setVmAutolockCdDrives
           , setVmHdType
           , cleanupArgoDevice
@@ -1851,6 +1853,8 @@ setVmTimerMode uuid v = saveConfigProperty uuid vmTimerMode (v::String)
 setVmNestedHvm uuid v = saveConfigProperty uuid vmNestedHvm (v::Bool)
 setVmSerial uuid v = saveConfigProperty uuid vmSerial (v::String)
 setVmBios uuid v = saveConfigProperty uuid vmBios (v::String)
+setVmSecureboot uuid v = saveConfigProperty uuid vmSecureboot (v::Bool)
+setVmAuthenforce uuid v = saveConfigProperty uuid vmAuthenforce (v::Bool)
 setVmHdType uuid v = saveConfigProperty uuid vmHdType (v::String)
 setVmDisplayHandlerStrict uuid v = saveConfigProperty uuid vmDisplayHandlerStrict (v::Bool)
 setVmLongForm uuid v = saveConfigProperty uuid vmLongForm (v::String)

--- a/xenmgr/Vm/Config.hs
+++ b/xenmgr/Vm/Config.hs
@@ -81,6 +81,8 @@ module Vm.Config (
                 , vmNestedHvm
                 , vmSerial
                 , vmBios
+                , vmSecureboot
+                , vmAuthenforce
                 , vmHdType
                 , vmDisplayHandlerStrict
                 , vmLongForm
@@ -498,6 +500,8 @@ vmSecondaryDomainColor = property "config.secondary-domain-color"
 vmStubdomMemory = property "config.stubdom-memory"
 vmStubdomCmdline = property "config.stubdom-cmdline"
 vmBios = property "config.bios"
+vmSecureboot = property "config.secureboot"
+vmAuthenforce = property "config.authenforce"
 vmHdType = property "config.hdtype"
 
 -- Composite ones and lists
@@ -915,6 +919,8 @@ miscSpecs cfg = do
           , ("iomem"           , vmPassthroughMmio) --ranges at a finer granularity. Few ways to implement, likely as a db-node with
           , ("ioports"         , vmPassthroughIo)   --each range as an entry beneath it, which is read and parsed during xl cfg generation.
           , ("bios"            , vmBios)
+          , ("secureboot"      , vmSecureboot) --set to False
+          , ("authenforce"     , vmAuthenforce) --set to True
           , ("initrd"          , vmInitrd)
           ]                                         --Remove this comment block when implemented.
 

--- a/xenmgr/Vm/Queries.hs
+++ b/xenmgr/Vm/Queries.hs
@@ -122,6 +122,8 @@ module Vm.Queries
                , getVmNestedHvm
                , getVmSerial
                , getVmBios
+               , getVmSecureboot
+               , getVmAuthenforce
                , getVmHdType
                , getVmDisplayHandlerStrict
                , getVmLongForm
@@ -1062,4 +1064,6 @@ getVmTimerMode uuid = readConfigPropertyDef uuid vmTimerMode vmTimerModeDefault
 getVmNestedHvm uuid = readConfigPropertyDef uuid vmNestedHvm False
 getVmSerial uuid = readConfigPropertyDef uuid vmSerial ""
 getVmBios uuid = readConfigPropertyDef uuid vmBios "seabios"
+getVmSecureboot uuid = readConfigPropertyDef uuid vmSecureboot False
+getVmAuthenforce uuid = readConfigPropertyDef uuid vmAuthenforce True
 getVmHdType uuid = readConfigPropertyDef uuid vmHdType "ide"

--- a/xenmgr/XenMgr/Expose/VmObject.hs
+++ b/xenmgr/XenMgr/Expose/VmObject.hs
@@ -707,6 +707,16 @@ implementationFor xm uuid = self where
   , comCitrixXenclientXenmgrVmSetBios = restrict' $ setVmBios uuid
   , comCitrixXenclientXenmgrVmUnrestrictedSetBios = setVmBios uuid
 
+  , comCitrixXenclientXenmgrVmGetSecureboot = getVmSecureboot uuid
+  , comCitrixXenclientXenmgrVmUnrestrictedGetSecureboot = getVmSecureboot uuid
+  , comCitrixXenclientXenmgrVmSetSecureboot = \v -> restrict >> setVmSecureboot uuid v
+  , comCitrixXenclientXenmgrVmUnrestrictedSetSecureboot = \v -> setVmSecureboot uuid v
+
+  , comCitrixXenclientXenmgrVmGetAuthenforce = getVmAuthenforce uuid
+  , comCitrixXenclientXenmgrVmUnrestrictedGetAuthenforce = getVmAuthenforce uuid
+  , comCitrixXenclientXenmgrVmSetAuthenforce = \v -> restrict >> setVmAuthenforce uuid v
+  , comCitrixXenclientXenmgrVmUnrestrictedSetAuthenforce = \v -> setVmAuthenforce uuid v
+
   , comCitrixXenclientXenmgrVmGetHdtype = getVmHdType uuid
   , comCitrixXenclientXenmgrVmUnrestrictedGetHdtype = getVmHdType uuid
   , comCitrixXenclientXenmgrVmSetHdtype = \v -> restrict >> setVmHdType uuid v


### PR DESCRIPTION
secureboot:
    - enable/disable secureboot
    - default is false
authenforce:
    - disallow modification to protected EFI vars if true
    - default is true

OXT-1826

Signed-off-by: Nicholas Tsirakis <tsirakisn@ainfosec.com>