### PR TITLE
dbd: Quiet debug logging

### DIFF
--- a/dbd/db_core.ml
+++ b/dbd/db_core.ml
@@ -327,7 +327,7 @@ and placement_in_dir nodes dir =
 	List.map place nodes
 
 let write_db ~unlink_files =
-	info "Updating database";
+	debug "Updating database";
 	(* go through placement rules and write using them *)
 	List.iter (fun rul -> write_db_using_rule ~unlink_files ~rul) rules;
 

--- a/dbd/db_core.ml
+++ b/dbd/db_core.ml
@@ -64,6 +64,8 @@ let rules = [
 	{ node_path = ["dom-store"]; place = FillDir "/config/dom-store" }
 ]
 
+let debugging = ref false
+
 (* tree is dirty when disk update is pending *)
 let tree_dirty = ref false
 
@@ -327,7 +329,7 @@ and placement_in_dir nodes dir =
 	List.map place nodes
 
 let write_db ~unlink_files =
-	debug "Updating database";
+	if !debugging then debug "Updating database";
 	(* go through placement rules and write using them *)
 	List.iter (fun rul -> write_db_using_rule ~unlink_files ~rul) rules;
 

--- a/dbd/db_methods.ml
+++ b/dbd/db_methods.ml
@@ -122,7 +122,7 @@ let com_citrix_xenclient_db_exists msg p =
 
 (* updates *)
 let com_citrix_xenclient_db_write msg p v =
-	debug "write %s %s %s" (sender_name msg) p v;
+	if !debugging then debug "write %s %s %s" (sender_name msg) p v;
 	let path = Tree.path_of_string ( get_domain_path_or_fail msg p ) in
 	let value = Json.String v in
 	tree := Tree.write !tree path value;
@@ -130,7 +130,7 @@ let com_citrix_xenclient_db_write msg p v =
 	()
 
 let com_citrix_xenclient_db_inject msg p v =
-	debug "inject %s %s %s" (sender_name msg) p v;
+	if !debugging then debug "inject %s %s %s" (sender_name msg) p v;
         let path = Tree.path_of_string ( get_domain_path_or_fail msg p ) in
         let json = Json_parse.of_string v in
         let value = Tree.of_json json in
@@ -139,7 +139,7 @@ let com_citrix_xenclient_db_inject msg p v =
 	()
 
 let com_citrix_xenclient_db_rm msg p =
-	debug "rm %s %s" (sender_name msg) p;
+	if !debugging then debug "rm %s %s" (sender_name msg) p;
 	let path = Tree.path_of_string ( get_domain_path_or_fail msg p ) in
 	tree := Tree.rm !tree path;
 	tree_dirty := true;

--- a/dbd/db_methods.ml
+++ b/dbd/db_methods.ml
@@ -122,7 +122,7 @@ let com_citrix_xenclient_db_exists msg p =
 
 (* updates *)
 let com_citrix_xenclient_db_write msg p v =
-	info "write %s %s %s" (sender_name msg) p v;
+	debug "write %s %s %s" (sender_name msg) p v;
 	let path = Tree.path_of_string ( get_domain_path_or_fail msg p ) in
 	let value = Json.String v in
 	tree := Tree.write !tree path value;
@@ -130,7 +130,7 @@ let com_citrix_xenclient_db_write msg p v =
 	()
 
 let com_citrix_xenclient_db_inject msg p v =
-	info "inject %s %s %s" (sender_name msg) p v;
+	debug "inject %s %s %s" (sender_name msg) p v;
         let path = Tree.path_of_string ( get_domain_path_or_fail msg p ) in
         let json = Json_parse.of_string v in
         let value = Tree.of_json json in
@@ -139,7 +139,7 @@ let com_citrix_xenclient_db_inject msg p v =
 	()
 
 let com_citrix_xenclient_db_rm msg p =
-	info "rm %s %s" (sender_name msg) p;
+	debug "rm %s %s" (sender_name msg) p;
 	let path = Tree.path_of_string ( get_domain_path_or_fail msg p ) in
 	tree := Tree.rm !tree path;
 	tree_dirty := true;

--- a/dbd/dbd.ml
+++ b/dbd/dbd.ml
@@ -58,8 +58,9 @@ let monitor_rpc_dbus pidfile =
 
 let _ =
 	let pidf = ref "" in
-	let speclist = [("--pidfile", Arg.Set_string pidf, "")] in
-	let usage_msg = "usage: dbd [--pidfile <filename>] [--help]" in
+	let speclist = [("--pidfile", Arg.Set_string pidf, "");
+			("--debug", Arg.Unit (fun() -> debugging := true), "")] in
+	let usage_msg = "usage: dbd [--pidfile <filename>] [--debug] [--help]" in
 	Arg.parse speclist (fun _ -> ()) usage_msg;
 
 	let pidfile = if !pidf <> "" then !pidf else default_pidfile in


### PR DESCRIPTION
dbd write logging is questionable.  The logging of the large dbd writes by varstored makes it undesirable.  The first patch lowers the write logging to syslog debug level, as well as "Updating database" mesages.  The second adds a `--debug` flag to stop generating the messages.

Complements guest UEFI https://github.com/OpenXT/xenclient-oe/pull/1434