### PR TITLE
dbd: Sleep longer

### DIFF
--- a/dbd/dbd.ml
+++ b/dbd/dbd.ml
@@ -41,7 +41,8 @@ let monitor_rpc_dbus pidfile =
 	let t0 = ref ( Unix.time() ) in
 	let dt_without_update = ref 0.0 in
 	while true do
-		ignore (DBus.Connection.read_write_dispatch bus 1000);
+		let sleep_time = if !tree_dirty then 3000 else -1 in
+		ignore (DBus.Connection.read_write_dispatch bus sleep_time);
 		let t1 = Unix.time () in
 		let dt = t1 -. !t0 in
 		t0 := t1;


### PR DESCRIPTION
dbd is a mostly idle daemon, but is wakes up every second.  Bump up the
sleep times to be idle longer.

There is already logic to write out a dirty tree at least every 3 seconds.
Therefore, the new logic sets a 3 second sleep as the minimum for use
when the tree is dirty.  If the tree is clean (either unchanged, or we
just flushed it), then we sleep indefinitely.  This should nicely remove
extraneous wakeups.

The existing time code tracks the last write.  When dbd has been idle
for 3 seconds, the next write is flushed immediate.  Subsequent writes
for the next 3 seconds queued up and are then flushed.  This does not
change with the patch.

Signed-off-by: Jason Andryuk <jandryuk@gmail.com>