### PR TITLE
xenmgr: Demote "active vm" messages to debug

### DIFF
--- a/xenmgr/XenMgr/Connect/Xl.hs
+++ b/xenmgr/XenMgr/Connect/Xl.hs
@@ -450,7 +450,7 @@ state uuid =
         maybe_state <- xsRead ("/state/" ++ show uuid ++ "/state")
         case maybe_state of
           Just state -> do
-                          info $ "active vm " ++ show uuid ++ " state = " ++ show state
+                          debug $ "active vm " ++ show uuid ++ " state = " ++ show state
                           return $ stateFromStr state
           Nothing    -> return $ stateFromStr "shutdown"
 


### PR DESCRIPTION
These can get excessive filling /var/log/messages.  It's unclear exactly
why, but make them debug so we don't see them.

Signed-off-by: Jason Andryuk <jandryuk@gmail.com>