### PR TITLE
Remove monitorAcpi thread

### DIFF
--- a/xenmgr/Vm/Actions.hs
+++ b/xenmgr/Vm/Actions.hs
@@ -775,20 +775,6 @@ setupAcpiNode uuid =
      case stubdom of
          Just stubdomid -> liftIO $ xsChmod (xsp domid ++ "/acpi-state") ("b" ++ show stubdomid)
          Nothing        -> liftIO $ xsChmod (xsp domid ++ "/acpi-state") ("b" ++ show domid)
- 
---Watch acpi state when booting a VM, used to be handled in xenvm
-monitorAcpi :: Uuid -> VmMonitor -> AcpiState -> IO ()
-monitorAcpi uuid m state = do
-    acpi_state <- Xl.acpiState uuid
-    if state == 5
-      then do return ()
-      else do
-        if state /= acpi_state
-          then do vmStateSubmit m acpi_state
-                  threadDelay (10^6)
-                  monitorAcpi uuid m acpi_state
-          else do threadDelay (10^6)
-                  monitorAcpi uuid m acpi_state
 
 -- Creates a snapshot from the primary disk when the disk persistence option is
 -- set. It first checks to see if a snapshot already exists and deletes it before
@@ -887,7 +873,6 @@ bootVm config reboot
        -- ensure bootstrap and phase handling synchronously terminates before returning (and errors get propagated)
        force bootstrap
        force phases
-       liftIO . void $ forkIO $ monitorAcpi uuid monitor 0
 
       writable domid path = do
         xsWrite path ""

--- a/xenmgr/Vm/Actions.hs
+++ b/xenmgr/Vm/Actions.hs
@@ -775,6 +775,10 @@ setupAcpiNode uuid =
      case stubdom of
          Just stubdomid -> liftIO $ xsChmod (xsp domid ++ "/acpi-state") ("b" ++ show stubdomid)
          Nothing        -> liftIO $ xsChmod (xsp domid ++ "/acpi-state") ("b" ++ show domid)
+     liftIO $ xsWrite (xsp domid ++ "/power-state") ("")
+     case stubdom of
+         Just stubdomid -> liftIO $ xsChmod (xsp domid ++ "/power-state") ("b" ++ show stubdomid)
+         Nothing        -> liftIO $ xsChmod (xsp domid ++ "/power-state") ("b" ++ show domid)
 
 -- Creates a snapshot from the primary disk when the disk persistence option is
 -- set. It first checks to see if a snapshot already exists and deletes it before

--- a/xenmgr/Vm/Monitor.hs
+++ b/xenmgr/Vm/Monitor.hs
@@ -71,6 +71,7 @@ data VmEvent
    | VmMeasurementFailure !FilePath !Integer !Integer
    | VmStateUpdate
    | VmAcpiUpdate
+   | VmPowerUpdate
      deriving (Eq,Show)
 
 data VmMonitor
@@ -288,5 +289,6 @@ watchesForVm submit =
     , newVmWatch "/attr/PVAddonsUninstalled" (submit VmPvAddonsUninstallNodeChange)
     , newVmWatch "/bsgdev" (submit VmBsgDevNodeChange)
     , newVmWatch "/acpi-state" (submit VmAcpiUpdate)
+    , newVmWatch "/power-state" (submit VmPowerUpdate)
     ]
 

--- a/xenmgr/Vm/React.hs
+++ b/xenmgr/Vm/React.hs
@@ -489,7 +489,7 @@ checkBsgDevStatus = uuidRpc $ \uuid -> whenDomainID_ uuid $ \domid ->
 -- 1 acpi state we care about: s3. Xenvm used to fork a thread that polled xen
 -- for domain acpi state with xc_hvm_param_get, which is BAD since xc_hvm_param_get
 -- makes a hypercall.Second, we can remove responsibility from inputserver to react
--- to acpi state changes (it shouldn't have to deal with that anyway). Third, we 
+-- to acpi state changes (it shouldn't have to deal with that anyway). Third, we
 -- won't have to patch libxl.
 reactVmAcpiUpdate :: Vm ()
 reactVmAcpiUpdate = do
@@ -497,12 +497,13 @@ reactVmAcpiUpdate = do
     whenDomainID_ uuid $ \domid -> do
       maybe_acpi <- liftIO $ xsRead ("/local/domain/" ++ show domid ++ "/acpi-state")
       case maybe_acpi of
-          Just acpi -> if acpi == "s3" then do switchVm domainUIVM 
-                                               notifyVmAcpiState 3
-                                               return () 
-                                       else return () 
-          Nothing   -> return () 
-   
+          Just "s3" -> do switchVm domainUIVM
+                          notifyVmAcpiState 3
+                          return ()
+          Just "s0" -> do notifyVmAcpiState 0
+                          return ()
+          _         -> return ()
+
 -- This is a new notify function to support state updates coming from xl
 -- Instead of implementing dbus support in xl, state updates are written to a
 -- xenstore node which XenMgr watches, which then fires off a dbus message, upon

--- a/xenmgr/Vm/React.hs
+++ b/xenmgr/Vm/React.hs
@@ -123,6 +123,18 @@ runEventScriptR = mkReact f where
     f (VmStateChange CreatingDomain) = return ()
     f (VmStateChange CreatingDevices) = return ()
     f (VmStateChange Created) = return ()
+    f (VmStateChange Running) =
+      do uuid <- vmUuid
+         liftRpc $ void $ runEventScript ContinueOnFail uuid getVmRunOnStateChange [uuidStr uuid, stateToPublicStr Running]
+         liftRpc $ void $ runEventScript ContinueOnFail uuid getVmRunOnAcpiStateChange [uuidStr uuid, "0"]
+    f (VmStateChange Suspended) =
+      do uuid <- vmUuid
+         liftRpc $ void $ runEventScript ContinueOnFail uuid getVmRunOnStateChange [uuidStr uuid, stateToPublicStr Suspended]
+         liftRpc $ void $ runEventScript ContinueOnFail uuid getVmRunOnAcpiStateChange [uuidStr uuid, "3"]
+    f (VmStateChange Shutdown) =
+      do uuid <- vmUuid
+         liftRpc $ void $ runEventScript ContinueOnFail uuid getVmRunOnStateChange [uuidStr uuid, stateToPublicStr Shutdown]
+         liftRpc $ void $ runEventScript ContinueOnFail uuid getVmRunOnAcpiStateChange [uuidStr uuid, "5"]
     f (VmStateChange state) =
       do uuid <- vmUuid
          liftRpc $ void $ runEventScript ContinueOnFail uuid getVmRunOnStateChange [uuidStr uuid, stateToPublicStr state]


### PR DESCRIPTION
xenmgr has a thread per-VM that polls the ACPI state once per second.  It actually forks two processes, xl uuid-to-domid and xl acpi-state.

Removing the thread noticably reduces xenmgr's CPU usage in top.  xenmgr can basically idle for 30 seconds between polling the disk usage.

All this ACPI stuff seems questionable.  I think it is mainly to support the run-on-acpi-state-change feature.  run-on-state-change seems better since the states are better handled by xenmgr.  I'd prefer to delete this ACPI state stuff if possible.

Also, VM S3 seems broken.  Windows 10 can't S3 as an OpenXT VM because the graphics subsystem prevents it.  However, I haven't checked if the vglass drivers allow it.  Linux detaches its PV disks on S3 resume, but the backend doesn't reconnect so it is basically dead.

S4 doesn't get reported out from Windows 10.  xenmgr just sees S5 poweroff.

I added code for VmStateChange Suspended, but that doesn't trigger.  If you S3 a Linux VM, it stays as "running".

Maybe these three commits should all be squashed together?