### PR TITLE
RFC/WIP: reboot with shutdown/start not reboot

### DIFF
--- a/xenmgr/Vm/Actions.hs
+++ b/xenmgr/Vm/Actions.hs
@@ -878,7 +878,8 @@ bootVm config reboot
                 then do 
                   if reboot 
                     then do liftIO $ Xl.signal uuid
-                    else do liftIO $ Xl.start uuid --we start paused by default
+                    else do tapenv <- tapEnvForVm uuid
+                            liftIO $ Xl.start uuid tapenv --we start paused by default
                 else do liftIO $ xsWrite (vmSuspendImageStatePath uuid) "resume"
                         liftIO $ Xl.resumeFromFile uuid suspend_file False True
          return bootstrap

--- a/xenmgr/Vm/Actions.hs
+++ b/xenmgr/Vm/Actions.hs
@@ -875,11 +875,8 @@ bootVm config reboot
                   then return False
                   else liftIO (doesFileExist suspend_file)
            if not exists
-                then do 
-                  if reboot 
-                    then do liftIO $ Xl.signal uuid
-                    else do tapenv <- tapEnvForVm uuid
-                            liftIO $ Xl.start uuid tapenv --we start paused by default
+                then do tapenv <- tapEnvForVm uuid
+                        liftIO $ Xl.start uuid tapenv --we start paused by default
                 else do liftIO $ xsWrite (vmSuspendImageStatePath uuid) "resume"
                         liftIO $ Xl.resumeFromFile uuid suspend_file False True
          return bootstrap

--- a/xenmgr/Vm/Config.hs
+++ b/xenmgr/Vm/Config.hs
@@ -606,6 +606,7 @@ getXlConfig cfg =
                           , "pci_msitranslate=1"
                           , "pci_seize=1"
                           , "pci_power_mgmt=1"
+                          , "on_reboot='destroy'"
                           ]
                             ++ nameStr
                             ++ hdtype

--- a/xenmgr/XenMgr/Connect/Xl.hs
+++ b/xenmgr/XenMgr/Connect/Xl.hs
@@ -232,8 +232,8 @@ signal uuid = do
 --It should be noted that by design, we start our domains paused to ensure all the
 --backend components are created and xenstore nodes are written before the domain
 --begins running.
-start :: Uuid -> IO ()
-start uuid =
+start :: Uuid -> [(String, String)] -> IO ()
+start uuid extraEnv =
     do
       --if domain already has a pid don't try to create another.
       pid <- getXlProcess uuid
@@ -243,7 +243,8 @@ start uuid =
           case state of
             Shutdown -> do
                           (_, _, Just err, handle) <- createProcess (proc "xl" ["create", configPath uuid, "-p"]){std_err = CreatePipe,
-                                  close_fds = True}
+                                  close_fds = True,
+                                  env = Just extraEnv}
                           ec <- waitForProcess handle
                           stderr <- hGetContents err
                           case ec of


### PR DESCRIPTION
This is only partially complete.  It's also on top of my Xen 4.14/4.16 work, so I included https://github.com/OpenXT/manager/commit/384380a634834b5e578266a7135397dcb4f77e95 to avoid conflicts and let the other two patches apply.

Today we issue xl reboot and use a signal to synchronize between xenmgr and xl.  This is needed since xenmgr issues the viptables commands which are needed for xl to talk QMP to stubdom's qemu for a successfully boot.  Actually with vchan-socket-proxy providing QMP proxying, and not using argo, that particular issue is gone.  But stubom still needs argo rules to connect back to helpers.

The idea here is our VMs can use `on_reboot='destroy'` in their config files to shutdown when rebooted.  With a patch to libxl, xenmgr can notice this and start the VM again for a reboot (and leave halted for a shutdown).  xl needs patching to extend the xenstore `/state/$uuid/state` tracking for a reboot, but then the signalling patch can be removed.

VM initiated/internal reboot works.

The external `xec-vm -n VM reboot` does not work.  While conceptually simple, my haskell is not strong enough.  Vm/Actions.hs:rebootVm is under/returns an `Rpc ()` monad, but startVm/restartVm return `XM ()` monads and I don't know how to mash those together.

Posting RFC to see if there is interest in pursuing this idea further.  Help on the monad mismatch would be appreciated.