### PR TITLE
xenmgr: Fix enable-dom0-networking

### DIFF
--- a/xenmgr/XenMgr/Config.hs
+++ b/xenmgr/XenMgr/Config.hs
@@ -72,6 +72,7 @@ import qualified Control.Exception as E
 import Data.List
 import Data.Maybe
 import Data.Char
+import System.Directory
 import System.IO
 import System.IO.Unsafe
 import System.Posix.Files
@@ -269,7 +270,9 @@ appSetEnableDom0Networking True =
       exist <- doesFileExist "/config/system/dom0-networking-disabled"
       if exist then removeFile "/config/system/dom0-networking-disabled" else return ()
 appSetEnableDom0Networking False =
-    liftIO $ writeFile "/config/system/dom0-networking-disabled" ""
+    liftIO $ do
+      createDirectoryIfMissing True "/config/system"
+      writeFile "/config/system/dom0-networking-disabled" ""
 
 appGetDom0MemTargetMIB :: Rpc Int
 appGetDom0MemTargetMIB = dbReadWithDefault 256 "/dom0-mem-target-mib"


### PR DESCRIPTION
Trying to disable dom0 networking by setting xenmgr.config propery enable-dom0-networking to False fails with:
223:IO error: /config/system/dom0-networking-disabled: openFile: does not exist (No such file or directory)

/config/system does not exist.  Ensure we create it if needed.

Signed-off-by: Jason Andryuk <jandryuk@gmail.com>