### PR TITLE
[xenmgr] Add idle shutdown specific call

### DIFF
--- a/xenmgr/XenMgr/Expose/HostObject.hs
+++ b/xenmgr/XenMgr/Expose/HostObject.hs
@@ -102,6 +102,7 @@ implementation xm host_info_cache = do
   , comCitrixXenclientXenmgrHostIsServiceRunning = isServiceRunning
 
   , comCitrixXenclientXenmgrHostShutdown  = runXM xm hostShutdown
+  , comCitrixXenclientXenmgrHostShutdownIdle  = runXM xm hostShutdownIdle
   , comCitrixXenclientXenmgrHostReboot    = runXM xm hostReboot
   , comCitrixXenclientXenmgrHostSleep     = runXM xm hostSleep
   , comCitrixXenclientXenmgrHostHibernate = runXM xm hostHibernate

--- a/xenmgr/XenMgr/HostOps.hs
+++ b/xenmgr/XenMgr/HostOps.hs
@@ -17,6 +17,7 @@
 --
 
 module XenMgr.HostOps ( hostShutdown
+                      , hostShutdownIdle
                       , hostSleep
                       , hostHibernate
                       , hostReboot
@@ -46,6 +47,9 @@ import XenMgr.Config
 -- These operations fail silently if host is not in idle state, i.e. is doing another action already
 hostShutdown :: XM ()
 hostShutdown = (hostWhenIdleDoWithState HostShuttingDown $ executePmAction ActionShutdown) >> return ()
+
+hostShutdownIdle :: XM ()
+hostShutdownIdle = executePmAction ActionIdleShutdown >> return ()
 
 hostSleep :: XM ()
 hostSleep = (hostWhenIdleDoWithState HostGoingToSleep $ executePmAction ActionSleep) >> return ()

--- a/xenmgr/XenMgr/PowerManagement.hs-boot
+++ b/xenmgr/XenMgr/PowerManagement.hs-boot
@@ -8,6 +8,7 @@ data PMAction = ActionSleep
               | ActionHibernate
               | ActionShutdown
 	      | ActionForcedShutdown
+	      | ActionIdleShutdown
               | ActionReboot
               | ActionNothing
               | ActionInvalid


### PR DESCRIPTION
  Implement a separate function for handling the idle shutdown
  case. When the system has been idle for the specified idle period
  and no user input has been detected, shutdown the platform. Start
  a 5 minute timer that will force the host off if has not completed
  the shutdown process.

  If the idle timer feature is enabled, then the expected behavior is
  that the host will be shutdown. This commit ensures that the host will
  reach the off state in the event of a stuck guest VM or otherwise non-
  responding process when handling an idle shutdown within a reasonable
  amount of time.

Signed-off-by: Chris Rogers <rogersc@ainfosec.com>