### PR TITLE
Hash VHD files

### DIFF
--- a/xenmgr/Vm/Actions.hs
+++ b/xenmgr/Vm/Actions.hs
@@ -1624,7 +1624,7 @@ extractFileFromPvDomain (Just dst_path) ext_loc uuid = withKernelPath dst_path w
 
 copyKernelFromDisk :: [ (String, String) ] -> Disk -> FilePath -> (Maybe PartitionNum,FilePath) -> IO ()
 copyKernelFromDisk extraEnv disk dst_path src
- = copyFileFromDisk extraEnv (diskType disk) (diskMode disk == ReadOnly) (diskPath disk) src dst_path
+ = copyFileFromDisk extraEnv (diskType disk) (diskPath disk) src dst_path
 
 changeVmNicNetwork :: Uuid -> NicID -> Network -> XM ()
 changeVmNicNetwork uuid nicid network = do

--- a/xenmgr/Vm/Utility.hs
+++ b/xenmgr/Vm/Utility.hs
@@ -55,16 +55,16 @@ type PartitionNum = Int
 finally' = flip E.finally
 
 mount :: FilePath -> FilePath -> Bool -> IO ()
-mount dev dir ro = void $ readProcessOrDie "mount" ["-o", opts, dev, dir] "" where
-  opts = intercalate "," . filter (not.null) $ [ro_opt]
-  ro_opt | ro = "ro"
-         | otherwise = ""
+mount dev dir ro = void $ readProcessOrDie "mount" (mountopts ++ [dev, dir]) "" where
+  mountopts = if ro then ["-o", "ro"] else []
 
 umount :: FilePath -> IO ()
 umount dir = void $ readProcessOrDie "umount" [dir] ""
 
 --Updated syntax for new tap-ctl style
-tapCreate ty extraEnv ro path = chomp <$> readProcessOrDieWithEnv extraEnv "tap-ctl" ( ["create"] ++ ["-a", ty++":"++path] ) ""
+tapCreate ty extraEnv ro path = chomp <$> readProcessOrDieWithEnv extraEnv "tap-ctl" ( ["create"] ++ ["-a", ty++":"++path] ++ ro_opt ) "" where
+  ro_opt | ro = ["-R"]
+         | otherwise = []
 tapCreateVhd = tapCreate "vhd"
 tapCreateVdi = tapCreate "vdi"
 tapCreateAio = tapCreate "aio"


### PR DESCRIPTION
Today, xenmgr hashes VHDs by creating tapdevs and hashing across the exposed contents.  This was done because `tap-ctl create` modifies .vhd metadata by default and hashing the .vhd file itself would be inconsistent.

If read-only tapdevs are created with `tap-ctl create -R`, the .vhd will not be modified.  By making xenmgr use read-only tapdevs, we can change to hashing across the .vhds.

This does mean that any use of `tap-ctl create` without `-R` would mess up the hashes.  A separate change to make `tap-ctl create` default to read-only, with `-W` to create writable, is forthcoming.