### PR TITLE
xenmgr: Fix printing vms on Firewall change

### DIFF
--- a/xenmgr/Vm/Actions.hs
+++ b/xenmgr/Vm/Actions.hs
@@ -1226,10 +1226,10 @@ doVmFirewallRules message which =
         (vms, vms') <- which
         seamlessVms <- getSeamlessVms
 
-        info $ "firewall rule delta vms:" 
+        info $ "firewall rule delta vms:"
         info $ "BEFORE: " ++ show vms
-        info $ "NOW: " ++ show vms
-        
+        info $ "NOW:    " ++ show vms'
+
         let reduce vms ((Firewall.ActiveVm _ _ vm _ _), rule) =
                 Firewall.reduce (Firewall.ReduceContext vm seamlessVms vms) [rule]
             vm_rules = mapM (getEffectiveVmFirewallRules . Firewall.vmUuid)


### PR DESCRIPTION
doVmFirewallRules prints vms for both before and after.  The after should be vms' to actually show the difference.

While doing this, align the text for easier comparison in the logs.

Clean up surrounding trailing whitespace while touching this.