### PR TITLE
xenmgr: Let sound=none disable it

### DIFF
--- a/xenmgr/Vm/Config.hs
+++ b/xenmgr/Vm/Config.hs
@@ -877,9 +877,13 @@ miscSpecs cfg = do
             True  -> do exists <- doesFileExist "/sys/firmware/acpi/tables/SLIC"
                         if exists then return [ "acpi_firmware='/sys/firmware/acpi/tables/SLIC'" ] else do info $ "SLIC table missing"
                                                                                                            return []
-            
+
       -- Activate sound
-      sound = maybeToList . fmap (("soundhw='"++) <$> (++"'")) <$> readConfigProperty uuid vmSound
+      sound = do
+          sound_type <- readConfigPropertyDef uuid vmSound "none"
+	  case sound_type of
+	    "none" -> return []
+	    _      -> return ["soundhw=" ++ wrapQuotes sound_type]
 
       -- Tells xl to use a stubdom or not
       stubdom | isHvm cfg && vmcfgStubdom cfg = return ["device_model_stubdomain_override=1"]


### PR DESCRIPTION
Let sound=none disable audio device for a VM.  Otherwise the dbd entry needs to be manually deleted to remove the audio device.