### PR TITLE
templates: Use grub-xen-pvh/pv64 for VMs

### DIFF
--- a/templates/default/new-vm-ndvm-pv
+++ b/templates/default/new-vm-ndvm-pv
@@ -43,7 +43,7 @@
     "memory": "192",
     "display": "none",
     "cmdline": "root=\/dev\/xvda2 iommu=soft console=hvc0",
-    "kernel-extract": "0,1:\/bzImage",
+    "kernel": "\/usr\/lib\/xen\/boot\/grub-xen-pv64",
     "flask-label": "system_u:system_r:ndvm_t",
     "disk": {
       "0": {

--- a/templates/default/new-vm-sync
+++ b/templates/default/new-vm-sync
@@ -24,7 +24,7 @@
     "memory": "256",
     "display": "none",
     "cmdline": "root=\/dev\/xvda1 console=hvc0",
-    "kernel-extract": "\/boot\/bzImage",
+    "kernel": "\/usr\/lib\/xen\/boot\/grub-xen-pvh",
     "flask-label": "system_u:system_r:syncvm_t",
     "nic": {
       "0": {

--- a/templates/default/service-ndvm-pv
+++ b/templates/default/service-ndvm-pv
@@ -47,7 +47,7 @@
     "memory": "192",
     "display": "none",
     "cmdline": "root=\/dev\/xvda2 iommu=soft console=hvc0",
-    "kernel-extract": "0,1:\/bzImage",
+    "kernel": "\/usr\/lib\/xen\/boot\/grub-xen-pv64",
     "flask-label": "system_u:system_r:ndvm_t",
     "pci": {
       "0": {

--- a/templates/default/service-uivm
+++ b/templates/default/service-uivm
@@ -69,7 +69,7 @@
     "memory": "256",
     "display": "none",
     "cmdline": "root=\/dev\/xvda1 console=hvc0",
-    "kernel-extract": "\/boot\/bzImage",
+    "kernel": "\/usr\/lib\/xen\/boot\/grub-xen-pvh",
     "flask-label": "system_u:system_r:uivm_t",
     "disk": {
       "0": {


### PR DESCRIPTION
Stop extracting the kernel and let these VMs boot via grub-xen-pvh or grub-xen-pv64 respectively.