### PR TITLE
xenmgr: Handle missing soundcards

### DIFF
--- a/xenmgr/XenMgr/Expose/HostObject.hs
+++ b/xenmgr/XenMgr/Expose/HostObject.hs
@@ -397,11 +397,13 @@ listSoundCards = liftIO
                  $ map kv
                  . catMaybes
                  . map parse
-                 . lines <$> readFile "/proc/asound/cards" where
+                 . lines <$> cards where
   parse line = case line `matchG` "\\s*(\\w+)\\s+\\[.*\\]: (.+)" of
     [id,name] -> Just (id,name)
     _ -> Nothing
   kv (id, name) = M.fromList [("id", id), ("name", name)]
+  cards = catch ( readFile "/proc/asound/cards" )
+                ( \e -> return "" )
 
 parseSSControl line =
  case line `matchG` "(.) '(.+)' (\\w+) (.*)" of

--- a/xenmgr/XenMgr/Host.hs
+++ b/xenmgr/XenMgr/Host.hs
@@ -805,7 +805,7 @@ hostSetLicense expiryDateStr deviceUuid hashStr = do
       when (before /= after) $ notifyLicenseChanged
 
 getHostPcmDevices :: IO [PcmDevice]
-getHostPcmDevices = catMaybes . map parseDev . lines <$> readFile "/proc/asound/pcm" where
+getHostPcmDevices = catMaybes . map parseDev . lines <$> pcmDevs where
   parseDev l = case map strip (split ':' l) of
     (idStr : name : _ : rest) ->
       Just $ PcmDevice
@@ -814,6 +814,8 @@ getHostPcmDevices = catMaybes . map parseDev . lines <$> readFile "/proc/asound/
                ("playback 1" `elem` rest)
                ("capture 1" `elem` rest)
     _ -> Nothing
+  pcmDevs = catch ( readFile "/proc/asound/pcm" )
+                  ( \e -> return "" )
 
 getHostPlaybackDevices = filter pcmPlayback <$> getHostPcmDevices
 getHostCaptureDevices = filter pcmCapture <$> getHostPcmDevices


### PR DESCRIPTION
When there is no sound card, the UI shows IO Error, and log files show: IO error: /proc/asound/pcm: openFile: does not exist (No such file or directory)

Catch the open errors (inside readFile) and return an empty string. Subsequent parsing won't match and there will be no devices returned.

Also handle /proc/asound/cards missing, which could occur if dom0 isn't built with sound card support.